### PR TITLE
mapexplorer-*: reverse reference arrow

### DIFF
--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -49,6 +49,7 @@
     "uuid": "^3.1.0"
   },
   "devDependencies": {
+    "@indigoframework/mapexplorer-core": "^0.2.0",
     "chai": "^4.1.2",
     "css.escape": "^1.5.1",
     "enzyme": "^3.1.0",

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -49,7 +49,6 @@
     "uuid": "^3.1.0"
   },
   "devDependencies": {
-    "@indigoframework/mapexplorer-core": "^0.2.0",
     "chai": "^4.1.2",
     "css.escape": "^1.5.1",
     "enzyme": "^3.1.0",

--- a/packages/angular-mapexplorer/docs/home.html
+++ b/packages/angular-mapexplorer/docs/home.html
@@ -73,13 +73,4 @@
       </md-tab>
     </md-tabs>
   </md-content>
-  <svg>
-    <marker id="triangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto">
-      <path fill="#999" d="M 0 0 L 10 5 L 0 10 z" />
-    </marker>
-    <marker id="blackTriangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3"
-      orient="auto">
-      <path fill="black" d="M 0 0 L 10 5 L 0 10 z" />
-    </marker>
-  </svg>
 </div>

--- a/packages/angular2-mapexplorer/docs_src/app/app.component.html
+++ b/packages/angular2-mapexplorer/docs_src/app/app.component.html
@@ -69,9 +69,4 @@
             </mat-tab>
         </mat-tab-group>
     </div>
-    <svg>
-        <marker id="triangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto">
-            <path fill="#CCCCCC" d="M 0 0 L 10 5 L 0 10 z" />
-        </marker>
-    </svg>
 </div>

--- a/packages/mapexplorer-core/assets/stylesheets/map.scss
+++ b/packages/mapexplorer-core/assets/stylesheets/map.scss
@@ -1,3 +1,15 @@
+#triangle {
+  fill: $link-color;
+}
+
+#reverseTriangle {
+  fill: $ref-link-color;
+}
+
+#blackTriangle {
+  fill: "black";
+}
+
 .node {
   cursor: pointer;
 }
@@ -27,6 +39,23 @@
   stroke: $link-color;
   stroke-width: 5px;
   marker-end: url("#triangle");
+}
+
+.link.references {
+  marker-end: none;
+}
+
+.link.references,
+.link.referencedBy {
+  stroke: $ref-link-color;
+}
+
+.link.references {
+  marker-start: 'url("#reverseTriangle")';
+}
+
+.link.referencedBy {
+  marker-end: 'url("#blackTriangle")';
 }
 
 path .link.ref:hover {

--- a/packages/mapexplorer-core/assets/stylesheets/variables.scss
+++ b/packages/mapexplorer-core/assets/stylesheets/variables.scss
@@ -9,6 +9,7 @@ $selected-segment-secondary-color: darken(#2be4a6, 20%) !default;
 $link-text-font: "Gibson-Regular", "Montserrat", sans-serif !default;
 $link-text-color: #293047 !default;
 $link-color: #999 !default;
+$ref-link-color: #000 !default;
 
 $merkle-path-node-color: black !default;
 $merkle-path-link-color: black !default;

--- a/packages/mapexplorer-core/package.json
+++ b/packages/mapexplorer-core/package.json
@@ -12,6 +12,7 @@
     "test": "yarn test:unit && yarn test:integration",
     "test:ci": "yarn test:unit:ci && yarn test:integration:ci",
     "build": "rollup -c rollup.npm.config.js && rollup -c rollup.browser.config.js",
+    "start": "rollup -c rollup.npm.config.js -w",
     "prepublish": "yarn build",
     "postpublish": "aws s3 cp dist/mapexplorer-core.js s3://stratumn-libs/mapexplorer-core.js --region 'eu-west-1' && aws s3 cp dist/mapexplorer-core.js s3://stratumn-libs/mapexplorer-core-${npm_package_version}.js --region 'eu-west-1'"
   },

--- a/packages/mapexplorer-core/src/ChainTreeBuilder.js
+++ b/packages/mapexplorer-core/src/ChainTreeBuilder.js
@@ -51,11 +51,11 @@ export const defaultOptions = {
     return `go to map ${compactHash(node.data.link.meta.mapId)}`;
   },
   getLinkText(link) {
-    if (
-      link.ref ||
-      link.target.data.parentRef === link.source.data.meta.linkHash
-    ) {
-      return 'reference';
+    if (link.ref) {
+      return 'references';
+    }
+    if (link.target.data.parentRef === link.source.data.meta.linkHash) {
+      return 'referenced by';
     }
     return (
       link.target.data.link.meta.action +

--- a/packages/mapexplorer-core/src/treeUtils.js
+++ b/packages/mapexplorer-core/src/treeUtils.js
@@ -14,17 +14,19 @@
   limitations under the License.
 */
 
-export function makeLink(source, target, margin = 0) {
+export function makeLink(source, target, marginTarget = 0, marginSource = 0) {
   const finalTarget = target || source;
   const targetX = finalTarget.x;
-  const targetY = finalTarget.y - margin;
-  return `M${source.y},${source.x}
-    C${(source.y + targetY) / 2},${source.x} ${(source.y + targetY) / 2},
+  const targetY = finalTarget.y - marginTarget;
+
+  const sourceY = source.y + marginSource;
+  return `M${sourceY},${source.x}
+    C${(sourceY + targetY) / 2},${source.x} ${(sourceY + targetY) / 2},
     ${targetX} ${targetY},${targetX}`;
 }
 
-export function finalLink(d, margin) {
-  return makeLink(d.source, d.target, margin);
+export function finalLink(d, marginTarget, marginSource = 0) {
+  return makeLink(d.source, d.target, marginTarget, marginSource);
 }
 
 export function translate(x, y) {

--- a/packages/react-mapexplorer/rollup.config.js
+++ b/packages/react-mapexplorer/rollup.config.js
@@ -17,13 +17,7 @@ export default {
       format: 'es'
     }
   ],
-  external: [
-    'react',
-    'react-dom',
-    'prop-types',
-    '@indigoframework/mapexplorer-core',
-    'radium'
-  ],
+  external: ['react', 'react-dom', 'prop-types', 'radium'],
   plugins: [
     babel({
       include: ['src/**']

--- a/packages/react-mapexplorer/rollup.config.js
+++ b/packages/react-mapexplorer/rollup.config.js
@@ -17,7 +17,13 @@ export default {
       format: 'es'
     }
   ],
-  external: ['react', 'react-dom', 'prop-types'],
+  external: [
+    'react',
+    'react-dom',
+    'prop-types',
+    '@indigoframework/mapexplorer-core',
+    'radium'
+  ],
   plugins: [
     babel({
       include: ['src/**']

--- a/packages/react-mapexplorer/src/MapExplorer.js
+++ b/packages/react-mapexplorer/src/MapExplorer.js
@@ -213,34 +213,8 @@ class MapExplorer extends Component {
       >
         <Style scopeSelector=".react-mapexplorer" rules={rules} />
         {segmentContainer}
-        <svg width="0">
-          <marker
-            id="triangle"
-            viewBox="0 0 10 10"
-            refX="0"
-            refY="5"
-            markerUnits="strokeWidth"
-            markerWidth="4"
-            markerHeight="3"
-            orient="auto"
-            style={styles.triangle}
-          >
-            <path fill="#CCCCCC" d="M 0 0 L 10 5 L 0 10 z" />
-          </marker>
-          <marker
-            id="blackTriangle"
-            viewBox="0 0 10 10"
-            refX="0"
-            refY="5"
-            markerUnits="strokeWidth"
-            markerWidth="4"
-            markerHeight="3"
-            orient="auto"
-            style={styles.triangle}
-          >
-            <path fill="black" d="M 0 0 L 10 5 L 0 10 z" />
-          </marker>
-        </svg>
+        {/* a empty div is needed here to make sure that d3 adds the svg below the segment container */}
+        <div />
       </div>
     );
   }

--- a/packages/react-mapexplorer/src/mapExplorerCss.js
+++ b/packages/react-mapexplorer/src/mapExplorerCss.js
@@ -30,6 +30,7 @@ export function getRules() {
   const foreignSegmentSecondaryColor = '#8B0000';
   const linkTextColor = '#6E6E6E';
   const linkColor = '#CCC';
+  const refLinkColor = '#000';
 
   return {
     color: 'white',
@@ -37,6 +38,18 @@ export function getRules() {
 
     'h1, h2, h4, li, a': {
       fontFamily: 'Gibson-SemiBold, Montserrat, sans-serif'
+    },
+
+    '#triangle': {
+      fill: linkColor
+    },
+
+    '#reverseTriangle': {
+      fill: refLinkColor
+    },
+
+    '#blackTriangle': {
+      fill: 'black'
     },
 
     h1: {
@@ -130,6 +143,18 @@ export function getRules() {
       markerEnd: 'url("#triangle")'
     },
 
+    '.link.references, .link.referencedBy': {
+      stroke: refLinkColor
+    },
+
+    '.link.references': {
+      markerStart: 'url("#reverseTriangle")'
+    },
+
+    '.link.referencedBy': {
+      markerEnd: 'url("#blackTriangle")'
+    },
+
     '.node.selected polygon': {
       fill: selectedSegmentPrimaryColor
     },
@@ -155,14 +180,11 @@ export function getRules() {
     },
 
     '#ref-link': {
-      strokeWidth: 8
-    },
-
-    '#ref-link:hover': {
+      strokeWidth: 8,
       stroke: 'black',
       cursor: 'pointer',
-      strokeWidth: 10,
-      markerEnd: 'url("#blackTriangle")'
+      markerEnd: 'url("#blackTriangle")',
+      markerStart: 'none'
     },
 
     'text#linkLabelRef': {
@@ -184,12 +206,6 @@ export function getRules() {
 
 export function getStyles() {
   return {
-    triangle: {
-      // get the svg that contains the arrow out of the flow
-      position: 'absolute',
-      pointerEvents: 'none'
-    },
-
     title: {
       background: '#040406',
       padding: '10px 100px',


### PR DESCRIPTION
and various improvements:
- deselect on click outside a segment
- factorize svg markers into mapexplorer-core

<img width="727" alt="capture d ecran 2018-03-15 a 17 45 06" src="https://user-images.githubusercontent.com/1303925/37478021-76a9a360-2879-11e8-8af6-1ad03918ff10.png">
<img width="952" alt="capture d ecran 2018-03-15 a 17 45 01" src="https://user-images.githubusercontent.com/1303925/37478024-76bffb7e-2879-11e8-8501-7ecd8def995a.png">
<img width="1004" alt="capture d ecran 2018-03-15 a 17 44 53" src="https://user-images.githubusercontent.com/1303925/37478025-76d4ee62-2879-11e8-91af-3c29ec415ced.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-indigocore/255)
<!-- Reviewable:end -->
