### PR TITLE
map-explorer: more data in TM evidence

### DIFF
--- a/packages/agent-ui/yarn.lock
+++ b/packages/agent-ui/yarn.lock
@@ -2,34 +2,6 @@
 # yarn lockfile v1
 
 
-"@indigoframework/client@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@indigoframework/client/-/client-0.2.0.tgz#c52381d24e7e5f4da21a5f2a5abae25de70d84a5"
-  dependencies:
-    deepmerge "2.0.1"
-    httpplease "^0.16.4"
-    qs stratumn/qs#rename-formats-default
-    setimmediate "^1.0.5"
-
-"@indigoframework/mapexplorer-core@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@indigoframework/mapexplorer-core/-/mapexplorer-core-0.2.0.tgz#fff31408d00749a9558265ab0880c536ea9efd5b"
-  dependencies:
-    "@indigoframework/client" "^0.2.0"
-    d3-array "^1.0.0"
-    d3-ease "^1.0.0"
-    d3-hierarchy "^1.0.0"
-    d3-selection "^1.0.0"
-    d3-transition "^1.0.1"
-    d3-zoom "^1.0.2"
-
-"@indigoframework/react-mapexplorer@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@indigoframework/react-mapexplorer/-/react-mapexplorer-0.2.0.tgz#8f4b0a158de8f607d62919fe9f5ca0082017f952"
-  dependencies:
-    "@indigoframework/mapexplorer-core" "^0.2.0"
-    radium "^0.19.5"
-
 "@types/jss@^9.3.0":
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.3.1.tgz#9e113f5d3e6bba6d8babca6be528b5cf19d37a16"
@@ -226,10 +198,6 @@ array-filter@~0.0.0:
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-
-array-find@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -1108,10 +1076,6 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bowser@^1.0.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.3.tgz#6643ae4d783f31683f6d23156976b74183862162"
-
 boxen@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
@@ -1846,68 +1810,6 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d3-array@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
-
-d3-color@1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
-
-d3-dispatch@1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.3.tgz#46e1491eaa9b58c358fce5be4e8bed626e7871f8"
-
-d3-drag@1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.1.tgz#df8dd4c502fb490fc7462046a8ad98a5c479282d"
-  dependencies:
-    d3-dispatch "1"
-    d3-selection "1"
-
-d3-ease@1, d3-ease@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.3.tgz#68bfbc349338a380c44d8acc4fbc3304aa2d8c0e"
-
-d3-hierarchy@^1.0.0:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz#a1c845c42f84a206bcf1c01c01098ea4ddaa7a26"
-
-d3-interpolate@1:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.6.tgz#2cf395ae2381804df08aa1bf766b7f97b5f68fb6"
-  dependencies:
-    d3-color "1"
-
-d3-selection@1, d3-selection@^1.0.0, d3-selection@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.0.tgz#d53772382d3dc4f7507bfb28bcd2d6aed2a0ad6d"
-
-d3-timer@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.7.tgz#df9650ca587f6c96607ff4e60cc38229e8dd8531"
-
-d3-transition@1, d3-transition@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.1.1.tgz#d8ef89c3b848735b060e54a39b32aaebaa421039"
-  dependencies:
-    d3-color "1"
-    d3-dispatch "1"
-    d3-ease "1"
-    d3-interpolate "1"
-    d3-selection "^1.1.0"
-    d3-timer "1"
-
-d3-zoom@^1.0.2:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.7.1.tgz#02f43b3c3e2db54f364582d7e4a236ccc5506b63"
-  dependencies:
-    d3-dispatch "1"
-    d3-drag "1"
-    d3-interpolate "1"
-    d3-selection "1"
-    d3-transition "1"
-
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1962,7 +1864,7 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@2.0.1, deepmerge@^2.0.1:
+deepmerge@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 
@@ -2652,10 +2554,6 @@ execa@^0.7.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
-
-exenv@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -3433,21 +3331,9 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-httpplease@^0.16.4:
-  version "0.16.4"
-  resolved "https://registry.yarnpkg.com/httpplease/-/httpplease-0.16.4.tgz#d382ebe230ef5079080b4e9ffebf316a9e75c0da"
-  dependencies:
-    urllite "~0.5.0"
-    xmlhttprequest "*"
-    xtend "~3.0.0"
-
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
-
-hyphenate-style-name@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
@@ -3518,13 +3404,6 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-
-inline-style-prefixer@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
-  dependencies:
-    bowser "^1.0.0"
-    hyphenate-style-name "^1.0.1"
 
 inquirer@3.3.0, inquirer@^3.0.6:
   version "3.3.0"
@@ -5681,7 +5560,7 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
-qs@6.5.1, qs@^6.5.1, "qs@github:stratumn/qs#rename-formats-default", qs@~6.5.1:
+qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://codeload.github.com/stratumn/qs/tar.gz/99fe1ec74140e09a51c41169264bad7924571945"
 
@@ -5711,15 +5590,6 @@ querystringify@0.0.x:
 querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
-
-radium@^0.19.5:
-  version "0.19.6"
-  resolved "https://registry.yarnpkg.com/radium/-/radium-0.19.6.tgz#b86721d08dbd303b061a4ae2ebb06cc6e335ae72"
-  dependencies:
-    array-find "^1.0.0"
-    exenv "^1.2.1"
-    inline-style-prefixer "^2.0.5"
-    prop-types "^15.5.8"
 
 raf@3.4.0, raf@^3.4.0:
   version "3.4.0"
@@ -7133,12 +7003,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urllite@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/urllite/-/urllite-0.5.0.tgz#1b7bb9ca3fb0db9520de113466bbcf7cc341451a"
-  dependencies:
-    xtend "~4.0.0"
-
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -7443,17 +7307,9 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xmlhttprequest@*:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
-
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0:
+xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-xtend@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-3.0.0.tgz#5cce7407baf642cba7becda568111c493f59665a"
 
 y18n@^3.2.1:
   version "3.2.1"

--- a/packages/angular-mapexplorer/src/stTmpopEvidence.directive.js
+++ b/packages/angular-mapexplorer/src/stTmpopEvidence.directive.js
@@ -3,6 +3,21 @@ export default function stTmpopEvidence() {
     scope: {
       evidence: '=?'
     },
+    link: scope => {
+      scope.evidence.votes = scope.evidence.proof.header_votes.map(
+        v => v.vote.validator_address
+      );
+      scope.evidence.validators = scope.evidence.proof.header_validator_set.validators.map(
+        v => v.address
+      );
+
+      scope.evidence.nextVotes = scope.evidence.proof.next_header_votes.map(
+        v => v.vote.validator_address
+      );
+      scope.evidence.nextValidators = scope.evidence.proof.next_header_validator_set.validators.map(
+        v => v.address
+      );
+    },
     templateUrl: '../views/tmpopevidence.html'
   };
 }

--- a/packages/angular-mapexplorer/test/fixtures/chainscript.json
+++ b/packages/angular-mapexplorer/test/fixtures/chainscript.json
@@ -40,6 +40,46 @@
               "data_hash": "OBj8lq6mSXgE9S7KRtTkAppQbuM=",
               "app_hash": "67pv8OR2/ISQtEoYc+3hN0z1UddUePspJkwD4mgUweM="
             },
+            "header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89091,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
+            },
             "next_header": {
               "chain_id": "test-chain-5AKxd9",
               "height": 89092,
@@ -50,6 +90,46 @@
               },
               "last_commit_hash": "GvkA0lEZ/ygQuBbo5v/qGqFy9bo=",
               "app_hash": "0U7AaZEW6gBI4Wk4Jg8vLTtgxkJFtXZRkTwWhnjiUVo="
+            },
+            "next_header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89092,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "next_header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
             }
           }
         }

--- a/packages/angular-mapexplorer/test/fixtures/chainscript.json
+++ b/packages/angular-mapexplorer/test/fixtures/chainscript.json
@@ -94,6 +94,46 @@
               "data_hash": "AUy1/CjR0+RfdV/dtIHRlmmhd5Q=",
               "app_hash": "hP+n+Y3Y88J95wkHmIeympvDCwJPN2RT1Te1jlIswHg="
             },
+            "header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 10080,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
+            },
             "next_header": {
               "chain_id": "test-chain-5AKxd9",
               "height": 10081,
@@ -104,6 +144,46 @@
               },
               "last_commit_hash": "WBz0BqCqNA0XMYsvWvAjkpMZVOY=",
               "app_hash": "9+7WT24R36eCaeRlJcPa+NdtV/Cqj2t0CR2Cr6A+jb0="
+            },
+            "next_header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 10081,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "next_header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
             }
           }
         }
@@ -149,6 +229,46 @@
               "data_hash": "8OR67Vhq/IdDBDceFsv2zO5EWoA=",
               "app_hash": "WgkmWitHZTa3/K9QH8tNVqJIuU7v3AgdNSsoUuIh3/s="
             },
+            "header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89166,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
+            },
             "next_header": {
               "chain_id": "test-chain-5AKxd9",
               "height": 89167,
@@ -159,6 +279,46 @@
               },
               "last_commit_hash": "x/ONHLdqGuTCMdZCBkX7re7KnVY=",
               "app_hash": "FWb7OCABQx7sykKmvlHKk17m+5pP2CRFc9JJug1ZdLI="
+            },
+            "next_header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89167,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "next_header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
             }
           }
         }
@@ -203,6 +363,46 @@
               "data_hash": "ZDob2ZJ3RvFtiP09QL0mqs6pcPE=",
               "app_hash": "eLtJR7SlL+WaVchoWiX+t5QCSZn1NFIaGcl0mT72N8U="
             },
+            "header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 8557,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
+            },
             "next_header": {
               "chain_id": "test-chain-5AKxd9",
               "height": 8558,
@@ -213,6 +413,46 @@
               },
               "last_commit_hash": "HQhP3Nm72rNgfA5Rm5hhiVyx4OA=",
               "app_hash": "+BDGTGS4bOACY9GevoT1TOOH+0hAIEeLH3lK2UZMkeQ="
+            },
+            "next_header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 8558,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "next_header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
             }
           }
         }
@@ -258,6 +498,46 @@
               "data_hash": "7v9FbHAhq2PDzbnR26JNmEoAuN4=",
               "app_hash": "UPyLR2LQxliYCM49QjoxYzv4L2BJTCJR6czQ7C/e+fQ="
             },
+            "header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89169,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
+            },
             "next_header": {
               "chain_id": "test-chain-5AKxd9",
               "height": 89170,
@@ -268,6 +548,46 @@
               },
               "last_commit_hash": "+DKFBoDGzXnDyeY3GawCGDqKukE=",
               "app_hash": "YpP4UN7/PvOgjoYGOWM3G4Vn/xuWPUeYxbaRMUW6tIY="
+            },
+            "next_header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89170,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "next_header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
             }
           }
         }
@@ -320,6 +640,46 @@
               "data_hash": "OBj8lq6mSXgE9S7KRtTkAppQbuM=",
               "app_hash": "67pv8OR2/ISQtEoYc+3hN0z1UddUePspJkwD4mgUweM="
             },
+            "header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89091,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
+            },
             "next_header": {
               "chain_id": "test-chain-5AKxd9",
               "height": 89092,
@@ -330,6 +690,46 @@
               },
               "last_commit_hash": "GvkA0lEZ/ygQuBbo5v/qGqFy9bo=",
               "app_hash": "0U7AaZEW6gBI4Wk4Jg8vLTtgxkJFtXZRkTwWhnjiUVo="
+            },
+            "next_header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89092,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "next_header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
             }
           }
         }
@@ -375,6 +775,46 @@
               "data_hash": "HVaqh+WqN73miTILP8PO2qcm+cA=",
               "app_hash": "QHOcThPJ6mgsRZT0IRSt00v8TsSId7q0htJHzUQQepE="
             },
+            "header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89236,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
+            },
             "next_header": {
               "chain_id": "test-chain-5AKxd9",
               "height": 89237,
@@ -387,6 +827,46 @@
               "last_commit_hash": "3yOk3nD/hiJzMHWuCAWCnvI1Iug=",
               "data_hash": "rREaKi3zOeL1HUhUl5LJonMVpyw=",
               "app_hash": "R7BB+nBveLV48CNvnplSmVKvIUXdfKWqQCN4JoMzqIM="
+            },
+            "next_header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89237,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "next_header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
             }
           }
         }
@@ -432,6 +912,46 @@
               "data_hash": "rREaKi3zOeL1HUhUl5LJonMVpyw=",
               "app_hash": "R7BB+nBveLV48CNvnplSmVKvIUXdfKWqQCN4JoMzqIM="
             },
+            "header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89237,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
+            },
             "next_header": {
               "chain_id": "test-chain-5AKxd9",
               "height": 89238,
@@ -442,6 +962,46 @@
               },
               "last_commit_hash": "zh5r4LtW/pWN/5ADWgsm/hUg0BA=",
               "app_hash": "ex9dZjCvI5iBVn/Ui9RCAw46rqbC3bO1LQ7h86YYn6Q="
+            },
+            "next_header_votes": [
+              {
+                "pub_key": {
+                  "type": "ed25519",
+                  "data":
+                    "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                },
+                "vote": {
+                  "validator_address":
+                    "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "validator_index": 0,
+                  "height": 89238,
+                  "round": 0,
+                  "type": 0,
+                  "block_id": {
+                    "hash": "600DC9E2706D8EEF1D8078DCF7EB267652745A39",
+                    "parts": { "total": 0, "hash": "" }
+                  },
+                  "signature": {
+                    "type": "ed25519",
+                    "data":
+                      "57BD6F49872B2DBA612C1C61A3B0EC79C8E8AFD3E73816F4616F362738D59DC42F22976D44374E522D4E0741D4A16E0618E7B3129A9DB61A3EE9B6E1F0A52007"
+                  }
+                }
+              }
+            ],
+            "next_header_validator_set": {
+              "validators": [
+                {
+                  "address": "B62F4950711E8B3A71E4E1DF63BD8041560D5F2A",
+                  "pub_key": {
+                    "type": "ed25519",
+                    "data":
+                      "A3682EE3EBF9E44B3A3E50748AD57CFBF8EFC65BDB8EBF39C47A2C613C41F00A"
+                  },
+                  "voting_power": 30,
+                  "accum": 0
+                }
+              ]
             }
           }
         }

--- a/packages/angular-mapexplorer/views/tmpopevidence.html
+++ b/packages/angular-mapexplorer/views/tmpopevidence.html
@@ -1,13 +1,55 @@
 <div class="evidence">
   <div class="info">
+    <h4>Chain ID</h4>
+    <p>{{evidence.provider}}</p>
+
+    <hr />
+
     <h4>Block #</h4>
-    <p>{{evidence.proof.block_height}}</p>
+    <p>{{evidence.proof.header.height}}</p>
 
     <h4>Time</h4>
     <p>{{evidence.proof.header.time}}</p>
 
+    <h4>Last Block</h4>
+    <p>{{evidence.proof.header.last_block_id.hash}}</p>
+
+    <h4>App Hash</h4>
+    <p>{{evidence.proof.header.app_hash}}</p>
+
+    <h4>Validators Hash</h4>
+    <p>{{evidence.proof.header.validators_hash}}</p>
+
+    <h4>Validators</h4>
+    <p>{{evidence.votes}}</p>
+
+    <h4>Expected Validators</h4>
+    <p>{{evidence.validators}}</p>
+
+    <hr />
+
+    <h4>Block #</h4>
+    <p>{{evidence.proof.next_header.height}}</p>
+
+    <h4>Time</h4>
+    <p>{{evidence.proof.next_header.time}}</p>
+
+    <h4>Last Block</h4>
+    <p>{{evidence.proof.next_header.last_block_id.hash}}</p>
+
     <h4>App Hash</h4>
     <p>{{evidence.proof.next_header.app_hash}}</p>
+
+    <h4>Validators Hash</h4>
+    <p>{{evidence.proof.next_header.validators_hash}}</p>
+
+    <h4>Validators</h4>
+    <p>{{evidence.nextVotes}}</p>
+
+    <h4>Expected Validators</h4>
+    <p>{{evidence.nextValidators}}</p>
+
+    <hr />
 
     <h4>Validations Hash</h4>
     <p>{{evidence.proof.validations_hash}}</p>

--- a/packages/angular2-mapexplorer/src/st-tmpop-evidence/st-tmpop-evidence.component.html
+++ b/packages/angular2-mapexplorer/src/st-tmpop-evidence/st-tmpop-evidence.component.html
@@ -16,14 +16,56 @@
 
 <div class="evidence">
   <div class="info">
+    <h4>Chain ID</h4>
+    <p>{{evidence.provider}}</p>
+
+    <hr />
+
     <h4>Block #</h4>
-    <p>{{evidence.proof.block_height}}</p>
+    <p>{{evidence.proof.header.height}}</p>
 
     <h4>Time</h4>
     <p>{{evidence.proof.header.time}}</p>
 
+    <h4>Last Block</h4>
+    <p>{{evidence.proof.header.last_block_id.hash}}</p>
+
+    <h4>App Hash</h4>
+    <p>{{evidence.proof.header.app_hash}}</p>
+
+    <h4>Validators Hash</h4>
+    <p>{{evidence.proof.header.validators_hash}}</p>
+
+    <h4>Validators</h4>
+    <p>{{votes()}}</p>
+
+    <h4>Expected Validators</h4>
+    <p>{{validators()}}</p>
+
+    <hr />
+
+    <h4>Block #</h4>
+    <p>{{evidence.proof.next_header.height}}</p>
+
+    <h4>Time</h4>
+    <p>{{evidence.proof.next_header.time}}</p>
+
+    <h4>Last Block</h4>
+    <p>{{evidence.proof.next_header.last_block_id.hash}}</p>
+
     <h4>App Hash</h4>
     <p>{{evidence.proof.next_header.app_hash}}</p>
+
+    <h4>Validators Hash</h4>
+    <p>{{evidence.proof.next_header.validators_hash}}</p>
+
+    <h4>Validators</h4>
+    <p>{{nextVotes()}}</p>
+
+    <h4>Expected Validators</h4>
+    <p>{{nextValidators()}}</p>
+
+    <hr />
 
     <h4>Validations Hash</h4>
     <p>{{evidence.proof.validations_hash}}</p>

--- a/packages/angular2-mapexplorer/src/st-tmpop-evidence/st-tmpop-evidence.component.ts
+++ b/packages/angular2-mapexplorer/src/st-tmpop-evidence/st-tmpop-evidence.component.ts
@@ -25,4 +25,26 @@ export class StTmpopEvidenceComponent {
   @Input() evidence;
 
   constructor(public element: ElementRef) {}
+
+  votes() {
+    return this.evidence.proof.header_votes.map(v => v.vote.validator_address);
+  }
+
+  validators() {
+    return this.evidence.proof.header_validator_set.validators.map(
+      v => v.address
+    );
+  }
+
+  nextVotes() {
+    return this.evidence.proof.next_header_votes.map(
+      v => v.vote.validator_address
+    );
+  }
+
+  nextValidators() {
+    return this.evidence.proof.next_header_validator_set.validators.map(
+      v => v.address
+    );
+  }
 }

--- a/packages/react-mapexplorer/src/BitcoinEvidence.js
+++ b/packages/react-mapexplorer/src/BitcoinEvidence.js
@@ -67,7 +67,6 @@ const BitcoinEvidence = ({ evidence }) => {
 
 BitcoinEvidence.propTypes = {
   evidence: PropTypes.shape({
-    state: PropTypes.string.isRequired,
     provider: PropTypes.String,
     backend: PropTypes.string,
     proof: PropTypes.object

--- a/packages/react-mapexplorer/src/DummyEvidence.js
+++ b/packages/react-mapexplorer/src/DummyEvidence.js
@@ -35,7 +35,6 @@ const DummyEvidence = ({ evidence }) => {
 
 DummyEvidence.propTypes = {
   evidence: PropTypes.shape({
-    state: PropTypes.string,
     provider: PropTypes.String,
     backend: PropTypes.string,
     proof: PropTypes.object

--- a/packages/react-mapexplorer/src/TMPopEvidence.js
+++ b/packages/react-mapexplorer/src/TMPopEvidence.js
@@ -17,6 +17,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import MerklePathComponent from './MerklePathComponent';
+import TMPopHeader from './TMPopHeader';
 
 const TMPopEvidence = ({ evidence }) => {
   let merkleTree;
@@ -37,14 +38,23 @@ const TMPopEvidence = ({ evidence }) => {
           <h4>Chain ID</h4>
           <p>{evidence.provider}</p>
 
-          <h4>Block #</h4>
-          <p>{evidence.proof.block_height}</p>
+          <hr />
 
-          <h4>Time</h4>
-          <p>{evidence.proof.header.time}</p>
+          <TMPopHeader
+            header={evidence.proof.header}
+            votes={evidence.proof.header_votes}
+            validators={evidence.proof.header_validator_set.validators}
+          />
 
-          <h4>App Hash</h4>
-          <p>{evidence.proof.next_header.app_hash}</p>
+          <hr />
+
+          <TMPopHeader
+            header={evidence.proof.next_header}
+            votes={evidence.proof.next_header_votes}
+            validators={evidence.proof.next_header_validator_set.validators}
+          />
+
+          <hr />
 
           <h4>Validations Hash</h4>
           <p>{evidence.proof.validations_hash}</p>
@@ -63,7 +73,7 @@ TMPopEvidence.propTypes = {
     provider: PropTypes.string,
     backend: PropTypes.string,
     proof: PropTypes.shape({
-      block_height: PropTypes.number,
+      merkle_root: PropTypes.string,
       validations_hash: PropTypes.string
     })
   }).isRequired

--- a/packages/react-mapexplorer/src/TMPopHeader.js
+++ b/packages/react-mapexplorer/src/TMPopHeader.js
@@ -1,0 +1,73 @@
+/*
+  Copyright 2017 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TMPopHeader = ({ header, votes, validators }) => (
+  <div>
+    <h4>Block #</h4>
+    <p>{header.height}</p>
+
+    <h4>Time</h4>
+    <p>{header.time}</p>
+
+    <h4>Last Block</h4>
+    <p>{header.last_block_id.hash}</p>
+
+    <h4>App Hash</h4>
+    <p>{header.app_hash}</p>
+
+    <h4>Validators Hash</h4>
+    <p>{header.validators_hash}</p>
+
+    <h4>Validators</h4>
+    <p>{votes.map(v => v.vote.validator_address)}</p>
+
+    <h4>Expected Validators</h4>
+    <p>{validators.map(v => v.address)}</p>
+  </div>
+);
+
+TMPopHeader.defaultProps = {
+  votes: []
+};
+
+TMPopHeader.propTypes = {
+  header: PropTypes.shape({
+    app_hash: PropTypes.string,
+    height: PropTypes.number,
+    last_block_id: PropTypes.shape({
+      hash: PropTypes.string
+    }),
+    time: PropTypes.string,
+    validators_hash: PropTypes.string
+  }).isRequired,
+  votes: PropTypes.arrayOf(
+    PropTypes.shape({
+      vote: PropTypes.shape({
+        validator_address: PropTypes.string
+      })
+    })
+  ),
+  validators: PropTypes.arrayOf(
+    PropTypes.shape({
+      address: PropTypes.string
+    })
+  ).isRequired
+};
+
+export default TMPopHeader;


### PR DESCRIPTION
Adding more data in TM evidence. The most useful one is probably the validators/expected validators section that can help quickly see that a validator is missing.
If we want the evidence to be easily understood by anyone, I think we need to do quite a bunch of design work to figure out how to visualize it. It will probably involve an interactive component to let the user dive into evidence parts, so it's quite a bit of work that requires better design skills than mine :)
That's also something that wouldn't be specific to us but would work for every project that uses Tendermint, so it might be worth doing that in a completely separate repo?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-indigocore/257)
<!-- Reviewable:end -->
