### PR TITLE
agent-client-js: keys use PEM format

### DIFF
--- a/packages/agent-client-js/package.json
+++ b/packages/agent-client-js/package.json
@@ -6,19 +6,15 @@
   "module": "lib/stratumn-agent-client.mjs",
   "browser": "lib/stratumn-agent-client.js",
   "scripts": {
-    "test":
-      "mocha --compilers js:babel-core/register --recursive --require babel-polyfill --require should ",
-    "test:ci":
-      "nyc yarn test && nyc report --reporter=text-lcov > coverage/coverage.lcov",
-    "build":
-      "rollup -c rollup.npm.config.js && rollup -c rollup.browser.config.js && rollup -c rollup.browser.min.config.js",
+    "test": "mocha --compilers js:babel-core/register --recursive --require babel-polyfill --require should ",
+    "test:ci": "nyc yarn test && nyc report --reporter=text-lcov > coverage/coverage.lcov",
+    "build": "rollup -c rollup.npm.config.js && rollup -c rollup.browser.config.js && rollup -c rollup.browser.min.config.js",
     "clean": "rimraf lib coverage",
     "preversion": "yarn clean && yarn test",
     "version": "yarn build",
     "postversion": "git push && git push --tags && yarn clean",
     "prepublish": "yarn clean && yarn build",
-    "postpublish":
-      "aws s3 cp dist/stratumn-agent-client.js s3://stratumn-libs/stratumn-agent-client.js --region 'eu-west-1' && aws s3 cp dist/stratumn-agent-client.min.js s3://stratumn-libs/stratumn-agent-client.min.js --region 'eu-west-1' && aws s3 cp dist/stratumn-agent-client.js s3://stratumn-libs/stratumn-agent-client-${npm_package_version}.js --region 'eu-west-1' && aws s3 cp dist/stratumn-agent-client.min.js s3://stratumn-libs/stratumn-agent-client-${npm_package_version}.min.js --region 'eu-west-1'"
+    "postpublish": "aws s3 cp dist/stratumn-agent-client.js s3://stratumn-libs/stratumn-agent-client.js --region 'eu-west-1' && aws s3 cp dist/stratumn-agent-client.min.js s3://stratumn-libs/stratumn-agent-client.min.js --region 'eu-west-1' && aws s3 cp dist/stratumn-agent-client.js s3://stratumn-libs/stratumn-agent-client-${npm_package_version}.js --region 'eu-west-1' && aws s3 cp dist/stratumn-agent-client.min.js s3://stratumn-libs/stratumn-agent-client-${npm_package_version}.min.js --region 'eu-west-1'"
   },
   "publishConfig": {
     "access": "public"
@@ -27,7 +23,12 @@
     "type": "git",
     "url": "https://github.com/stratumn/js-indigocore.git"
   },
-  "keywords": ["stratumn", "sdk", "blockchain", "client"],
+  "keywords": [
+    "stratumn",
+    "sdk",
+    "blockchain",
+    "client"
+  ],
   "author": "Stratumn Team",
   "license": "Apache-2.0",
   "bugs": {
@@ -48,26 +49,26 @@
     "mocha": "^2.4.5",
     "nyc": "^11.2.1",
     "rimraf": "^2.5.2",
-    "rollup": "^0.50.0",
+    "rollup": "^0.57.1",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.0.0",
-  	"rollup-plugin-json": "^2.1.0",
-	  "rollup-plugin-node-builtins": "^2.1.2",
-    "rollup-plugin-node-resolve": "^3.0.0",
-  	"rollup-plugin-uglify": "^3.0.0",
+    "rollup-plugin-json": "^2.1.0",
+    "rollup-plugin-node-builtins": "^2.1.2",
+    "rollup-plugin-node-resolve": "^3.3.0",
+    "rollup-plugin-uglify": "^3.0.0",
     "rollup-pluginutils": "^2.0.1",
-	  "setimmediate": "^1.0.5",
+    "setimmediate": "^1.0.5",
     "should": "^8.2.2"
   },
   "dependencies": {
     "@indigoframework/utils": "^0.2.0",
-    "asn1.js": "^4.10.1",
+    "asn1.js": "stratumn/asn1.js#master",
+    "canonicaljson": "1.0.1",
     "deepmerge": "2.0.1",
     "httpplease": "^0.16.4",
+    "jmespath": "^0.15.0",
     "qs": "stratumn/qs#rename-formats-default",
-    "canonicaljson": "1.0.1",
-    "tweetnacl": "1.0.0",
-    "jmespath": "^0.15.0"
+    "tweetnacl": "1.0.0"
   },
   "resolutions": {
     "xmlhttprequest": "1.7.0"

--- a/packages/agent-client-js/package.json
+++ b/packages/agent-client-js/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@indigoframework/utils": "^0.2.0",
+    "asn1.js": "^4.10.1",
     "deepmerge": "2.0.1",
     "httpplease": "^0.16.4",
     "qs": "stratumn/qs#rename-formats-default",

--- a/packages/agent-client-js/rollup.browser.config.js
+++ b/packages/agent-client-js/rollup.browser.config.js
@@ -31,6 +31,7 @@ export default {
         'node_modules/qs/lib/index.js': ['stringify'],
         'node_modules/canonicaljson/lib/canonicaljson.js': ['stringify'],
         'node_modules/jmespath/jmespath.js': ['search'],
+        'node_modules/asn1.js/lib/asn1.js': ['define'],
         '../utils/lib/index.js': ['promiseWhile']
       }
     })

--- a/packages/agent-client-js/rollup.browser.config.js
+++ b/packages/agent-client-js/rollup.browser.config.js
@@ -6,9 +6,7 @@ import babel from 'rollup-plugin-babel';
 import babelrc from 'babelrc-rollup';
 
 export default {
-  sourcemap: true,
   input: 'src/index.js',
-  name: 'StratumnAgentClient',
   plugins: [
     babel(
       Object.assign(
@@ -31,12 +29,14 @@ export default {
         'node_modules/qs/lib/index.js': ['stringify'],
         'node_modules/canonicaljson/lib/canonicaljson.js': ['stringify'],
         'node_modules/jmespath/jmespath.js': ['search'],
-        'node_modules/asn1.js/lib/asn1.js': ['define'],
+        'node_modules/asn1.js/dist/asn1.js': ['define'],
         '../utils/lib/index.js': ['promiseWhile']
       }
     })
   ],
   output: {
+    sourcemap: true,
+    name: 'StratumnAgentClient',
     format: 'umd',
     file: 'dist/stratumn-agent-client.js'
   }

--- a/packages/agent-client-js/rollup.browser.min.config.js
+++ b/packages/agent-client-js/rollup.browser.min.config.js
@@ -3,6 +3,7 @@ import config from './rollup.browser.config';
 
 config.plugins.push(uglify());
 config.output = {
+  name: 'StratumnAgentClient',
   file: 'dist/stratumn-agent-client.min.js',
   format: 'iife'
 };

--- a/packages/agent-client-js/rollup.npm.config.js
+++ b/packages/agent-client-js/rollup.npm.config.js
@@ -6,7 +6,6 @@ const pkg = require('./package.json');
 export default {
   sourcemap: true,
   input: 'src/index.js',
-  name: 'StratumnAgentClient',
   external: Object.keys(pkg.dependencies),
   plugins: [
     babel(
@@ -20,10 +19,14 @@ export default {
   ],
   output: [
     {
+      sourcemap: true,
+      name: 'StratumnAgentClient',
       file: pkg.module,
       format: 'es'
     },
     {
+      sourcemap: true,
+      name: 'StratumnAgentClient',
       file: pkg.main,
       format: 'cjs'
     }

--- a/packages/agent-client-js/src/encoding.js
+++ b/packages/agent-client-js/src/encoding.js
@@ -74,14 +74,17 @@ export function encodePEM(data, label) {
 
 export function decodePEM(data) {
   const lines = data.split(/\r?\n/);
+  if (lines.length < 3) {
+    throw new Error('string is not PEM encoded');
+  }
   const beginRE = new RegExp(`-----\\s*BEGIN (.*)\\s*-----`);
   const endRE = new RegExp(`-----\\s*END (.*)\\s*-----`);
   const tagBegin = lines[0].match(beginRE);
   const tagEnd = lines[lines.length - 1].match(endRE);
-  if (!tagBegin || !tagEnd || tagBegin[1] !== tagEnd[1]) {
-    throw new Error(
-      'Missing PEM label, or mismatch between BEGIN and END labels'
-    );
+  if (!tagBegin || !tagEnd || !tagBegin[1]) {
+    throw new Error('Missing PEM label');
+  } else if (tagBegin[1] !== tagEnd[1]) {
+    throw new Error('Mismatch between BEGIN and END labels');
   }
   return {
     body: Buffer.from(lines.slice(1, lines.length - 1).join(''), 'base64'),

--- a/packages/agent-client-js/src/encoding.js
+++ b/packages/agent-client-js/src/encoding.js
@@ -1,0 +1,155 @@
+/*
+  Copyright 2017 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { define } from 'asn1.js';
+
+export const publicKeyOIDs = {
+  'ED25519 PUBLIC KEY': [1, 3, 101, 112],
+  'RSA PUBLIC KEY': [1, 2, 840, 113549, 1, 1, 1],
+  'EC PUBLIC KEY': [1, 2, 840, 10045, 2, 1]
+};
+
+// ASN.1 ED25519 SECRET KEY ENCODER
+function Asn1Signature() {
+  this.octstr();
+}
+const SignatureEncoder = define('Asn1Signature', Asn1Signature);
+
+function Asn1ED25519SecretKey() {
+  this.octstr();
+}
+const Ed25519SecretKeyEncoder = define(
+  'Asn1ED25519SecretKey',
+  Asn1ED25519SecretKey
+);
+
+// ASN.1 PUBLIC KEY ENCODER
+function Asn1AlgorithmIdentifier() {
+  this.seq().obj(
+    this.key('algorithm').objid(),
+    this.key('parameters')
+      .optional()
+      .any()
+  );
+}
+const AlgorithmIdentifierEncoder = define(
+  'AlgorithmIdentifier',
+  Asn1AlgorithmIdentifier
+);
+
+function Asn1PublicKey() {
+  this.seq().obj(
+    this.key('algorithm').use(AlgorithmIdentifierEncoder),
+    this.key('publicKey').bitstr()
+  );
+}
+const PublicKeyEncoder = define('Asn1PublicKey', Asn1PublicKey);
+
+// API
+
+export function encodePEM(data, label) {
+  if (!label) {
+    throw new Error('PEM encoding failed: missing label');
+  }
+
+  const p = data.toString('base64');
+  const out = [`-----BEGIN ${label}-----`];
+  for (let i = 0; i < p.length; i += 64) out.push(p.slice(i, i + 64));
+  out.push(`-----END ${label}-----`);
+  return out.join('\n');
+}
+
+export function decodePEM(data) {
+  const lines = data.split(/\r?\n/);
+  const beginRE = new RegExp(`-----\\s*BEGIN (.*)\\s*-----`);
+  const endRE = new RegExp(`-----\\s*END (.*)\\s*-----`);
+  const tagBegin = lines[0].match(beginRE);
+  const tagEnd = lines[lines.length - 1].match(endRE);
+  if (!tagBegin || !tagEnd || tagBegin[1] !== tagEnd[1]) {
+    throw new Error(
+      'Missing PEM label, or mismatch between BEGIN and END labels'
+    );
+  }
+  return {
+    body: Buffer.from(lines.slice(1, lines.length - 1).join(''), 'base64'),
+    label: tagBegin[1]
+  };
+}
+
+export function encodePKToPEM(publicKey, keyType) {
+  let ASN1Bytes;
+  try {
+    const algorithm = publicKeyOIDs[keyType];
+    if (!algorithm) {
+      throw new Error('unknown public key algorithm');
+    }
+    ASN1Bytes = PublicKeyEncoder.encode(
+      {
+        algorithm: { algorithm },
+        publicKey: { data: publicKey }
+      },
+      'der'
+    );
+  } catch (e) {
+    throw new Error(`Could not encode public key: ${e.message}`);
+  }
+  return encodePEM(ASN1Bytes, keyType);
+}
+
+export function decodePKFromPEM(key) {
+  const ASN1Bytes = decodePEM(key);
+  const publicKeyInfo = PublicKeyEncoder.decode(ASN1Bytes.body, 'der');
+  return {
+    publicKey: publicKeyInfo.publicKey.data,
+    type: ASN1Bytes.label
+  };
+}
+
+export function encodeSKToPEM(key, keyType) {
+  let ASN1Bytes;
+  try {
+    ASN1Bytes = Ed25519SecretKeyEncoder.encode(key, 'der');
+  } catch (e) {
+    throw new Error(`Could not encode public key: ${e.message}`);
+  }
+  return encodePEM(ASN1Bytes, keyType);
+}
+
+export function decodeSKFromPEM(key) {
+  const ASN1Bytes = decodePEM(key);
+  return {
+    secretKey: Ed25519SecretKeyEncoder.decode(ASN1Bytes.body, 'der'),
+    type: ASN1Bytes.label
+  };
+}
+
+export function encodeSignatureToPEM(signature) {
+  let ASN1Bytes;
+  try {
+    ASN1Bytes = SignatureEncoder.encode(signature, 'der');
+  } catch (e) {
+    throw new Error(`Could not encode signature: ${e}`);
+  }
+  return encodePEM(ASN1Bytes, 'MESSAGE');
+}
+
+export function decodeSignatureFromPEM(signature) {
+  const ASN1Bytes = decodePEM(signature);
+  return {
+    signature: SignatureEncoder.decode(ASN1Bytes.body, 'der'),
+    type: ASN1Bytes.label
+  };
+}

--- a/packages/agent-client-js/src/encoding.js
+++ b/packages/agent-client-js/src/encoding.js
@@ -23,11 +23,6 @@ export const publicKeyOIDs = {
 };
 
 // ASN.1 ED25519 SECRET KEY ENCODER
-function Asn1Signature() {
-  this.octstr();
-}
-const SignatureEncoder = define('Asn1Signature', Asn1Signature);
-
 function Asn1ED25519SecretKey() {
   this.octstr();
 }
@@ -140,19 +135,13 @@ export function decodeSKFromPEM(key) {
 }
 
 export function encodeSignatureToPEM(signature) {
-  let ASN1Bytes;
-  try {
-    ASN1Bytes = SignatureEncoder.encode(signature, 'der');
-  } catch (e) {
-    throw new Error(`Could not encode signature: ${e}`);
-  }
-  return encodePEM(ASN1Bytes, 'MESSAGE');
+  return encodePEM(signature, 'MESSAGE');
 }
 
 export function decodeSignatureFromPEM(signature) {
-  const ASN1Bytes = decodePEM(signature);
+  const { body, label } = decodePEM(signature);
   return {
-    signature: SignatureEncoder.decode(ASN1Bytes.body, 'der'),
-    type: ASN1Bytes.label
+    signature: body,
+    type: label
   };
 }

--- a/packages/agent-client-js/src/sign.js
+++ b/packages/agent-client-js/src/sign.js
@@ -19,6 +19,8 @@ import { sign as naclSign } from 'tweetnacl';
 import { stringify } from 'canonicaljson/lib/canonicaljson.js';
 import { search } from 'jmespath';
 
+import { encodeSignatureToPEM } from './encoding';
+
 const attributesMap = {
   inputs: 'meta.inputs',
   action: 'meta.action',
@@ -111,12 +113,12 @@ export const sign = (key, data) =>
     const payloadBytes = Buffer.from(stringify(payloadData));
 
     // sign the payload and resolve with the signature
-    const signature = naclSign.detached(payloadBytes, key.secret);
+    const signature = Buffer.from(naclSign.detached(payloadBytes, key.secret));
 
     resolve({
       type: key.type,
       publicKey: key.public,
-      signature: Buffer.from(signature).toString('base64'),
+      signature: encodeSignatureToPEM(signature),
       payload: payload
     });
   });

--- a/packages/agent-client-js/test/createMap.js
+++ b/packages/agent-client-js/test/createMap.js
@@ -18,11 +18,10 @@ import { sign as nacl } from 'tweetnacl';
 import { runTestsWithDataAndAgent } from './utils/testSetUp';
 
 describe('#createMap', () => {
-  const testKey = {
-    type: 'ed25519'
-  };
-  const { secretKey } = nacl.keyPair();
-  testKey.secret = Buffer.from(secretKey).toString('base64');
+  const testKey = `-----BEGIN ED25519 PRIVATE KEY-----
+BEA9W3XFkpyKTi/IS8oIf6dFaUL9LbSJiFCobv59peBPZnyM26JsiOYAcfuUpWH9
+elNreOq3rs5cfAkY6vdaDrtm
+-----END ED25519 PRIVATE KEY-----`;
 
   runTestsWithDataAndAgent(processCb => {
     it('creates a map', () =>

--- a/packages/agent-client-js/test/createMap.js
+++ b/packages/agent-client-js/test/createMap.js
@@ -14,7 +14,6 @@
   limitations under the License.
 */
 
-import { sign as nacl } from 'tweetnacl';
 import { runTestsWithDataAndAgent } from './utils/testSetUp';
 
 describe('#createMap', () => {

--- a/packages/agent-client-js/test/encoding.js
+++ b/packages/agent-client-js/test/encoding.js
@@ -155,22 +155,23 @@ BFVsvHaVt+putNZGntbUraRS
 describe('#encodeSignatureToPEM', () => {
   const tag = 'MESSAGE';
   const fakeSig = randomBuffer(nacl.signatureLength);
-  it('encodes a byte array to a PEM string containing the ASN.1 representation of a signed signature', () => {
+
+  it('encodes a byte array signature to a PEM string', () => {
     const PEMSig = encodeSignatureToPEM(fakeSig, tag);
     decodePEM(PEMSig, { tag }).should.not.throw();
     decodeSignatureFromPEM(PEMSig).signature.should.deepEqual(fakeSig);
   });
 
   it('handles bad signature format', () =>
-    (() => encodeSignatureToPEM({})).should.throw());
+    (() => encodeSignatureToPEM(null)).should.throw());
 });
 
 describe('#decodeSignatureFromPEM', () => {
   const testPEMSignature = `-----BEGIN MESSAGE-----
-BEDZR29+Zk8M72ZlgWstb3o96MdKNXeT0Q7LfzDFQKjv9dLjeHpRL4BSjkjPWbuA
-Kmq1nHIk7T7bpLBohyy0lRYO
+epuH8CD4adt7XVG8A5tFUAN+X0bV9ytanYWjCofsITg35gdXAKPiwMWa5hcdKGnG
+kOdXBkj4/e30X6rvntzeCA==
 -----END MESSAGE-----`;
-  it('decodes o a PEM string containing the ASN.1 representation of a signed message to a byte array', () => {
+  it('decodes o a PEM string containing the signature to a byte array', () => {
     const { signature, type } = decodeSignatureFromPEM(testPEMSignature);
     signature.length.should.be.exactly(nacl.signatureLength);
     encodeSignatureToPEM(signature, type).should.be.exactly(testPEMSignature);

--- a/packages/agent-client-js/test/encoding.js
+++ b/packages/agent-client-js/test/encoding.js
@@ -1,0 +1,151 @@
+/*
+  Copyright 2017 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+import { sign as nacl } from 'tweetnacl';
+
+import {
+  decodePEM,
+  encodePKToPEM,
+  decodePKFromPEM,
+  encodeSKToPEM,
+  decodeSKFromPEM,
+  encodeSignatureToPEM,
+  decodeSignatureFromPEM
+} from '../src/encoding';
+
+const randomBuffer = length =>
+  Buffer.from(
+    new Uint8Array(length).map(() => Math.random() * Math.floor(255))
+  );
+
+describe('#encodePEM', () => {});
+
+describe('#decodePEM', () => {});
+
+describe('#encodePKToPEM', () => {
+  const keyType = 'ED25519 PUBLIC KEY';
+  const fakePK = randomBuffer(nacl.publicKeyLength);
+  it('encodes a byte array to a PEM string containing the ASN.1 representation of a public key', () => {
+    const PKInfo = encodePKToPEM(fakePK, keyType);
+    decodePEM(PKInfo, keyType).should.not.throw();
+    decodePKFromPEM(PKInfo, keyType).should.deepEqual({
+      publicKey: fakePK,
+      type: keyType
+    });
+  });
+
+  it('handles bad key types', () =>
+    (() => encodePKToPEM(fakePK, 'bad')).should.throw(
+      'Could not encode public key: unknown public key algorithm'
+    ));
+
+  it('handles bad key format', () =>
+    (() => encodePKToPEM({}, keyType)).should.throw(
+      'Could not encode public key: Unsupported type: object at: ["publicKey"]'
+    ));
+});
+
+describe('#decodePKFromPEM', () => {
+  const testPEMPublicKey = `-----BEGIN ED25519 PUBLIC KEY-----
+MCowBQYDK2VwAyEA4lGE3bR+ZeEO3N8dOjAEVWy8dpW36m601kae1tStpFI=
+-----END ED25519 PUBLIC KEY-----`;
+
+  it('decodes a PEM string containing the ASN.1 representation of a public key to a byte array', () => {
+    const { publicKey, type } = decodePKFromPEM(testPEMPublicKey);
+    publicKey.length.should.be.exactly(nacl.publicKeyLength);
+    encodePKToPEM(publicKey, type).should.be.exactly(testPEMPublicKey);
+  });
+
+  it('handles bad key types', () =>
+    (() =>
+      decodePKFromPEM(testPEMPublicKey.replace('ED25519', 'BAD'))).should.throw(
+      'Missing PEM label, or mismatch between BEGIN and END labels'
+    ));
+
+  it('handles bad key format', () =>
+    (() => decodePKFromPEM({})).should.throw());
+});
+
+describe('#encodeSKToPEM', () => {
+  const keyType = 'ED25519 PUBLIC KEY';
+  const fakeSK = randomBuffer(nacl.secretKeyLength);
+  it('encodes a byte array to a PEM string containing the ASN.1 representation of a secret key', () => {
+    const SKInfo = encodeSKToPEM(fakeSK, keyType);
+    decodePEM(SKInfo, { tag: keyType }).should.not.throw();
+    decodeSKFromPEM(SKInfo, keyType).should.deepEqual({
+      secretKey: fakeSK,
+      type: keyType
+    });
+  });
+
+  it('handles bad key types', () =>
+    (() => encodePKToPEM(fakeSK, 'bad')).should.throw(
+      'Could not encode public key: unknown public key algorithm'
+    ));
+
+  it('handles bad key format', () =>
+    (() => encodePKToPEM({}, keyType)).should.throw());
+});
+
+describe('#decodeSKFromPEM', () => {
+  const testPEMPrivateKey = `-----BEGIN ED25519 PRIVATE KEY-----
+BEAu3UcG9B1K7E7YbzeVUJPbU9v62rSQPSr87rCbPkwCg+JRhN20fmXhDtzfHTow
+BFVsvHaVt+putNZGntbUraRS
+-----END ED25519 PRIVATE KEY-----`;
+  it('decodes a PEM string containing the ASN.1 representation of a public key to a byte array', () => {
+    const { secretKey, type } = decodeSKFromPEM(testPEMPrivateKey);
+    secretKey.length.should.be.exactly(nacl.secretKeyLength);
+    encodeSKToPEM(secretKey, type).should.be.exactly(testPEMPrivateKey);
+  });
+
+  it('handles bad key types', () =>
+    (() =>
+      decodeSKFromPEM(
+        testPEMPrivateKey.replace('ED25519', 'BAD')
+      )).should.throw(
+      'Missing PEM label, or mismatch between BEGIN and END labels'
+    ));
+
+  it('handles bad key format', () =>
+    (() => decodeSKFromPEM({})).should.throw());
+});
+
+describe('#encodeSignatureToPEM', () => {
+  const tag = 'MESSAGE';
+  const fakeSig = randomBuffer(nacl.signatureLength);
+  it('encodes a byte array to a PEM string containing the ASN.1 representation of a signed signature', () => {
+    const PEMSig = encodeSignatureToPEM(fakeSig, tag);
+    decodePEM(PEMSig, { tag }).should.not.throw();
+    decodeSignatureFromPEM(PEMSig).signature.should.deepEqual(fakeSig);
+  });
+
+  it('handles bad signature format', () =>
+    (() => encodeSignatureToPEM({})).should.throw());
+});
+
+describe('#decodeSignatureFromPEM', () => {
+  const testPEMSignature = `-----BEGIN MESSAGE-----
+BEDZR29+Zk8M72ZlgWstb3o96MdKNXeT0Q7LfzDFQKjv9dLjeHpRL4BSjkjPWbuA
+Kmq1nHIk7T7bpLBohyy0lRYO
+-----END MESSAGE-----`;
+  it('decodes o a PEM string containing the ASN.1 representation of a signed message to a byte array', () => {
+    const { signature, type } = decodeSignatureFromPEM(testPEMSignature);
+    signature.length.should.be.exactly(nacl.signatureLength);
+    encodeSignatureToPEM(signature, type).should.be.exactly(testPEMSignature);
+  });
+
+  it('handles bad signature format', () =>
+    (() => decodeSignatureFromPEM(null)).should.throw());
+});

--- a/packages/agent-client-js/test/segmentify.js
+++ b/packages/agent-client-js/test/segmentify.js
@@ -14,15 +14,13 @@
   limitations under the License.
 */
 
-import { sign as nacl } from 'tweetnacl';
 import { runTestsWithDataAndAgent } from './utils/testSetUp';
 
 describe('#segmentify', () => {
-  const testKey = {
-    type: 'ed25519'
-  };
-  const { secretKey } = nacl.keyPair();
-  testKey.secret = Buffer.from(secretKey).toString('base64');
+  const testKey = `-----BEGIN ED25519 PRIVATE KEY-----
+BEA9W3XFkpyKTi/IS8oIf6dFaUL9LbSJiFCobv59peBPZnyM26JsiOYAcfuUpWH9
+elNreOq3rs5cfAkY6vdaDrtm
+-----END ED25519 PRIVATE KEY-----`;
 
   runTestsWithDataAndAgent(processCb => {
     it('adds actions to the segment', () =>

--- a/packages/agent-client-js/test/sign.js
+++ b/packages/agent-client-js/test/sign.js
@@ -20,6 +20,15 @@ import { runTestsWithDataAndAgent } from './utils/testSetUp';
 
 import { sign, signedProperties } from '../src/sign';
 import { withKey } from '../src/withKey';
+import { decodeSignatureFromPEM, decodePKFromPEM } from '../src/encoding';
+
+const testPrivateKey = `-----BEGIN ED25519 PRIVATE KEY-----
+BEAu3UcG9B1K7E7YbzeVUJPbU9v62rSQPSr87rCbPkwCg+JRhN20fmXhDtzfHTow
+BFVsvHaVt+putNZGntbUraRS
+-----END ED25519 PRIVATE KEY-----`;
+const testPublicKey = `-----BEGIN ED25519 PUBLIC KEY-----
+MCowBQYDK2VwAyEA4lGE3bR+ZeEO3N8dOjAEVWy8dpW36m601kae1tStpFI=
+-----END ED25519 PUBLIC KEY-----`;
 
 describe('#signedProperties', () => {
   runTestsWithDataAndAgent(processCb => {
@@ -59,14 +68,7 @@ describe('#signedProperties', () => {
 });
 
 describe('#sign', () => {
-  const pair = nacl.keyPair();
-  const testKey = withKey(
-    {},
-    {
-      type: 'ed25519',
-      secret: Buffer.from(pair.secretKey).toString('base64')
-    }
-  ).key;
+  const testKey = withKey({}, testPrivateKey).key;
 
   const testData = {
     refs: [{ test: 'test' }],
@@ -80,11 +82,7 @@ describe('#sign', () => {
       sig.payload.should.be.exactly(
         '[meta.refs[*].linkHash,meta.action,meta.prevLinkHash,meta.inputs]'
       );
-      sig.publicKey.should.be.exactly(
-        Buffer.from(
-          nacl.keyPair.fromSecretKey(pair.secretKey).publicKey
-        ).toString('base64')
-      );
+      sig.publicKey.should.be.exactly(testPublicKey);
     }));
 
   it('build the payload accordingly to the provided data', () =>
@@ -97,6 +95,8 @@ describe('#sign', () => {
   it('outputs a valid signature', () =>
     sign(testKey, { ...testData, inputs: false }).then(sig => {
       const { signature, publicKey } = sig;
+      const publicKeyBytes = decodePKFromPEM(publicKey).publicKey;
+      const signatureBytes = decodeSignatureFromPEM(signature).signature;
       const payloadBytes = Buffer.from(
         stringify([
           testData.refs.map(r => r.linkHash).filter(Boolean),
@@ -106,42 +106,11 @@ describe('#sign', () => {
       );
       const verif = nacl.detached.verify(
         payloadBytes,
-        Buffer.from(signature, 'base64'),
-        Buffer.from(publicKey, 'base64')
+        signatureBytes,
+        publicKeyBytes
       );
       verif.should.be.true();
     }));
-
-  it('outputs a valid signature with an externally generated key', () => {
-    const externalKey = withKey(
-      {},
-      {
-        type: 'ed25519',
-        secret:
-          'yFQwrc9r3afEjXJgPCWmrsDFIu74kpzeO45JlvT0DR/DMi29TsL0kD4ljTNHo65MntarqAYF4iprgkGTRkVuCw=='
-      }
-    ).key;
-
-    return sign(externalKey, { ...testData, inputs: false }).then(sig => {
-      const { signature, publicKey } = sig;
-      const payloadBytes = Buffer.from(
-        stringify([
-          testData.refs.map(r => r.linkHash).filter(Boolean),
-          testData.action,
-          testData.prevLinkHash
-        ])
-      );
-      publicKey.should.be.exactly(
-        'wzItvU7C9JA+JY0zR6OuTJ7Wq6gGBeIqa4JBk0ZFbgs='
-      );
-      const verif = nacl.detached.verify(
-        payloadBytes,
-        Buffer.from(signature, 'base64'),
-        Buffer.from(publicKey, 'base64')
-      );
-      verif.should.be.true();
-    });
-  });
 
   it('fails if the provided data does not match [inputs, action, refs, prevLinkHash]', () =>
     sign(testKey, { ...testData, unknown: 'test' })

--- a/packages/agent-client-js/test/withKey.js
+++ b/packages/agent-client-js/test/withKey.js
@@ -14,31 +14,26 @@
   limitations under the License.
 */
 
-import { sign as nacl } from 'tweetnacl';
 import { runTestsWithDataAndAgent } from './utils/testSetUp';
+import { decodeSKFromPEM } from '../src/encoding';
 
 describe('#withKey', () => {
-  const testKey = {
-    type: 'ed25519'
-  };
-  const { secretKey } = nacl.keyPair();
-  testKey.secret = Buffer.from(secretKey).toString('base64');
-
-  const testExternalSecretKey = Buffer.from(
-    'OihdFSC22di2UPIwFObCw5t+XYkdXVcqNVLHq6LuPt3lP0QqTZbhYwzI7Kt9hDQCGmRABxVZATByyXu+myKP8w==',
-    'base64'
-  );
+  const testPrivateKey = `-----BEGIN ED25519 PRIVATE KEY-----
+BEAu3UcG9B1K7E7YbzeVUJPbU9v62rSQPSr87rCbPkwCg+JRhN20fmXhDtzfHTow
+BFVsvHaVt+putNZGntbUraRS
+-----END ED25519 PRIVATE KEY-----`;
+  const testPublicKey = `-----BEGIN ED25519 PUBLIC KEY-----
+MCowBQYDK2VwAyEA4lGE3bR+ZeEO3N8dOjAEVWy8dpW36m601kae1tStpFI=
+-----END ED25519 PUBLIC KEY-----`;
 
   runTestsWithDataAndAgent(processCb => {
     it('adds a "key" property to a process', () =>
       processCb()
-        .withKey(testKey)
+        .withKey(testPrivateKey)
         .key.should.deepEqual({
-          type: 'ed25519',
-          secret: Buffer.from(testKey.secret, 'base64'),
-          public: Buffer.from(
-            Buffer.from(testKey.secret, 'base64').slice(nacl.publicKeyLength)
-          ).toString('base64')
+          type: decodeSKFromPEM(testPrivateKey).type,
+          secret: decodeSKFromPEM(testPrivateKey).secretKey,
+          public: testPublicKey
         }));
 
     it('adds a "key" property to a segment', () =>
@@ -46,45 +41,30 @@ describe('#withKey', () => {
         .createMap('first')
         .then(segment =>
           segment
-            .withKey(testKey)
+            .withKey(testPrivateKey)
             .key.should.have.properties(['type', 'secret', 'public'])
         ));
 
     it('the key can be inherited from a parent', () =>
       processCb()
-        .withKey(testKey)
+        .withKey(testPrivateKey)
         .createMap('first')
         .then(segment =>
           segment.key.should.have.properties(['type', 'secret', 'public'])
         ));
 
-    it('works with a key created externally', () =>
-      processCb()
-        .withKey({
-          type: 'ed25519',
-          secret: testExternalSecretKey.toString('base64')
-        })
-        .createMap('first')
-        .then(segment =>
-          segment.key.should.deepEqual({
-            type: 'ed25519',
-            secret: Buffer.from(testExternalSecretKey, 'base64'),
-            public: Buffer.from(
-              Buffer.from(testExternalSecretKey, 'base64').slice(
-                nacl.publicKeyLength
-              )
-            ).toString('base64')
-          })
-        ));
-
     it('fails when signature schema is not handled', () =>
-      (() => processCb().withKey({ ...testKey, type: 'unknown' })).should.throw(
-        'unknown : Unhandled key type'
-      ));
+      (() =>
+        processCb().withKey(
+          `-----BEGIN UNKNOWN PRIVATE KEY-----
+BEAu3UcG9B1K7E7YbzeVUJPbU9v62rSQPSr87rCbPkwCg+JRhN20fmXhDtzfHTow
+BFVsvHaVt+putNZGntbUraRS
+-----END UNKNOWN PRIVATE KEY-----`
+        )).should.throw('Could not parse key: unhandled key type'));
 
     it('fails when key format is wrong', () =>
-      (() => processCb().withKey({ test: 'test' })).should.throw(
-        "key object must comply to the format : {type: 'ed25519', secret: 'YOURSECRETKEY'}"
+      (() => processCb().withKey('test')).should.throw(
+        'Missing PEM label, or mismatch between BEGIN and END labels'
       ));
   });
 });

--- a/packages/agent-client-js/test/withKey.js
+++ b/packages/agent-client-js/test/withKey.js
@@ -64,7 +64,7 @@ BFVsvHaVt+putNZGntbUraRS
 
     it('fails when key format is wrong', () =>
       (() => processCb().withKey('test')).should.throw(
-        'Missing PEM label, or mismatch between BEGIN and END labels'
+        'string is not PEM encoded'
       ));
   });
 });

--- a/packages/agent-client-js/yarn.lock
+++ b/packages/agent-client-js/yarn.lock
@@ -93,7 +93,7 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asn1.js@^4.0.0:
+asn1.js@^4.0.0, asn1.js@^4.10.1:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
   dependencies:

--- a/packages/agent-client-js/yarn.lock
+++ b/packages/agent-client-js/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@types/acorn@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.3.tgz#d1f3e738dde52536f9aad3d3380d14e448820afd"
+  dependencies:
+    "@types/estree" "*"
+
+"@types/estree@*", "@types/estree@0.0.38":
+  version "0.0.38"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -11,6 +21,16 @@ abstract-leveldown@~0.12.0, abstract-leveldown@~0.12.1:
   resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz#29e18e632e60e4e221d5810247852a63d7b2e410"
   dependencies:
     xtend "~3.0.0"
+
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  dependencies:
+    acorn "^5.0.0"
+
+acorn@^5.0.0, acorn@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
 acorn@^5.1.1:
   version "5.1.2"
@@ -93,9 +113,17 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asn1.js@^4.0.0, asn1.js@^4.10.1:
+asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
+asn1.js@stratumn/asn1.js#master:
+  version "5.0.0"
+  resolved "https://codeload.github.com/stratumn/asn1.js/tar.gz/7b0cae00d36c57d85e0acdb244105bedd2a1f729"
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -642,12 +670,6 @@ brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
-browser-resolve@^1.11.0:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
-  dependencies:
-    resolve "1.1.7"
-
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.1.1.tgz#38b7ab55edb806ff2dcda1a7f1620773a477c49f"
@@ -710,9 +732,13 @@ buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.0:
+builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+builtin-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-2.0.0.tgz#60b7ef5ae6546bd7deefa74b08b62a43a232648e"
 
 caching-transform@^1.0.0:
   version "1.0.1"
@@ -934,6 +960,12 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-time@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2"
+  dependencies:
+    time-zone "^1.0.0"
 
 debug-log@^1.0.1:
   version "1.0.1"
@@ -1423,6 +1455,10 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+irregular-plurals@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1510,6 +1546,12 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+
+is-reference@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.0.tgz#50e6ef3f64c361e2c53c0416cdc9420037f2685b"
+  dependencies:
+    "@types/estree" "0.0.38"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -1778,6 +1820,10 @@ load-json-file@^2.0.0:
     parse-json "^2.2.0"
     pify "^2.0.0"
     strip-bom "^3.0.0"
+
+locate-character@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-2.0.5.tgz#f2d2614d49820ecb3c92d80d193b8db755f74c0f"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -2161,6 +2207,10 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-ms@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -2231,9 +2281,22 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+plur@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a"
+  dependencies:
+    irregular-plurals "^1.0.0"
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+pretty-ms@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-3.1.0.tgz#e9cac9c76bf6ee52fe942dd9c6c4213153b12881"
+  dependencies:
+    parse-ms "^1.0.0"
+    plur "^2.1.2"
 
 private@^0.1.6, private@^0.1.7:
   version "0.1.8"
@@ -2492,13 +2555,13 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
-
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.1.6, resolve@^1.1.7, resolve@^1.4.0:
   version "1.4.0"
@@ -2556,12 +2619,11 @@ rollup-plugin-node-builtins@^2.1.2:
     crypto-browserify "^3.11.0"
     process-es6 "^0.11.2"
 
-rollup-plugin-node-resolve@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
+rollup-plugin-node-resolve@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz#c26d110a36812cbefa7ce117cadcd3439aa1c713"
   dependencies:
-    browser-resolve "^1.11.0"
-    builtin-modules "^1.1.0"
+    builtin-modules "^2.0.0"
     is-module "^1.0.0"
     resolve "^1.1.6"
 
@@ -2585,9 +2647,21 @@ rollup-pluginutils@^2.0.1:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
 
-rollup@^0.50.0:
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.50.0.tgz#4c158f4e780e6cb33ff0dbfc184a52cc58cd5f3b"
+rollup@^0.57.1:
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.57.1.tgz#0bb28be6151d253f67cf4a00fea48fb823c74027"
+  dependencies:
+    "@types/acorn" "^4.0.3"
+    acorn "^5.5.3"
+    acorn-dynamic-import "^3.0.0"
+    date-time "^2.1.0"
+    is-reference "^1.1.0"
+    locate-character "^2.0.5"
+    pretty-ms "^3.1.0"
+    require-relative "^0.8.7"
+    rollup-pluginutils "^2.0.1"
+    signal-exit "^3.0.2"
+    sourcemap-codec "^1.4.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -2695,6 +2769,10 @@ source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
 source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+sourcemap-codec@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz#c8fd92d91889e902a07aee392bdd2c5863958ba2"
 
 spawn-wrap@^1.3.8:
   version "1.3.8"
@@ -2842,6 +2920,10 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+time-zone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
 
 to-fast-properties@^1.0.3:
   version "1.0.3"

--- a/packages/angular2-mapexplorer/yarn.lock
+++ b/packages/angular2-mapexplorer/yarn.lock
@@ -3268,7 +3268,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-karma-chrome-launcher@^2.0.0:
+karma-chrome-launcher@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
   dependencies:

--- a/packages/cs-validator/package.json
+++ b/packages/cs-validator/package.json
@@ -43,7 +43,6 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.11.6",
     "babelrc-rollup": "^3.0.0",
-    "crypto-browserify": "^3.11.0",
     "karma": "^1.1.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",

--- a/packages/ember-mapexplorer/yarn.lock
+++ b/packages/ember-mapexplorer/yarn.lock
@@ -20,27 +20,6 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@indigoframework/client@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@indigoframework/client/-/client-0.2.0.tgz#c52381d24e7e5f4da21a5f2a5abae25de70d84a5"
-  dependencies:
-    deepmerge "2.0.1"
-    httpplease "^0.16.4"
-    qs stratumn/qs#rename-formats-default
-    setimmediate "^1.0.5"
-
-"@indigoframework/mapexplorer-core@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@indigoframework/mapexplorer-core/-/mapexplorer-core-0.2.0.tgz#fff31408d00749a9558265ab0880c536ea9efd5b"
-  dependencies:
-    "@indigoframework/client" "^0.2.0"
-    d3-array "^1.0.0"
-    d3-ease "^1.0.0"
-    d3-hierarchy "^1.0.0"
-    d3-selection "^1.0.0"
-    d3-transition "^1.0.1"
-    d3-zoom "^1.0.2"
-
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -2052,68 +2031,6 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d3-array@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
-
-d3-color@1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
-
-d3-dispatch@1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.3.tgz#46e1491eaa9b58c358fce5be4e8bed626e7871f8"
-
-d3-drag@1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.1.tgz#df8dd4c502fb490fc7462046a8ad98a5c479282d"
-  dependencies:
-    d3-dispatch "1"
-    d3-selection "1"
-
-d3-ease@1, d3-ease@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.3.tgz#68bfbc349338a380c44d8acc4fbc3304aa2d8c0e"
-
-d3-hierarchy@^1.0.0:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz#a1c845c42f84a206bcf1c01c01098ea4ddaa7a26"
-
-d3-interpolate@1:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.6.tgz#2cf395ae2381804df08aa1bf766b7f97b5f68fb6"
-  dependencies:
-    d3-color "1"
-
-d3-selection@1, d3-selection@^1.0.0, d3-selection@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.0.tgz#d53772382d3dc4f7507bfb28bcd2d6aed2a0ad6d"
-
-d3-timer@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.7.tgz#df9650ca587f6c96607ff4e60cc38229e8dd8531"
-
-d3-transition@1, d3-transition@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.1.1.tgz#d8ef89c3b848735b060e54a39b32aaebaa421039"
-  dependencies:
-    d3-color "1"
-    d3-dispatch "1"
-    d3-ease "1"
-    d3-interpolate "1"
-    d3-selection "^1.1.0"
-    d3-timer "1"
-
-d3-zoom@^1.0.2:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.7.1.tgz#02f43b3c3e2db54f364582d7e4a236ccc5506b63"
-  dependencies:
-    d3-dispatch "1"
-    d3-drag "1"
-    d3-interpolate "1"
-    d3-selection "1"
-    d3-transition "1"
-
 dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
@@ -2169,10 +2086,6 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-
-deepmerge@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -3978,14 +3891,6 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-httpplease@^0.16.4:
-  version "0.16.4"
-  resolved "https://registry.yarnpkg.com/httpplease/-/httpplease-0.16.4.tgz#d382ebe230ef5079080b4e9ffebf316a9e75c0da"
-  dependencies:
-    urllite "~0.5.0"
-    xmlhttprequest "*"
-    xtend "~3.0.0"
 
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.19"
@@ -5812,7 +5717,7 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
-qs@6.5.1, qs@^6.4.0, qs@stratumn/qs#rename-formats-default, qs@~6.5.1:
+qs@6.5.1, qs@^6.4.0, qs@~6.5.1:
   version "6.5.1"
   resolved "https://codeload.github.com/stratumn/qs/tar.gz/99fe1ec74140e09a51c41169264bad7924571945"
 
@@ -6389,10 +6294,6 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 setprototypeof@1.0.3:
   version "1.0.3"
@@ -7140,12 +7041,6 @@ url-to-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
 
-urllite@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/urllite/-/urllite-0.5.0.tgz#1b7bb9ca3fb0db9520de113466bbcf7cc341451a"
-  dependencies:
-    xtend "~4.0.0"
-
 use@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
@@ -7362,17 +7257,9 @@ xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
 
-xmlhttprequest@*:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
-
 xtend@^4.0.0, xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-xtend@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-3.0.0.tgz#5cce7407baf642cba7becda568111c493f59665a"
 
 y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"

--- a/packages/mapexplorer-core/package.json
+++ b/packages/mapexplorer-core/package.json
@@ -45,7 +45,6 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.11.6",
     "babelrc-rollup": "^3.0.0",
-    "crypto-browserify": "^3.11.0",
     "karma": "^1.1.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",


### PR DESCRIPTION
The old key format (json with `secret` and `type` attributes) was replaced by the PEM format. This allows us to increase the compatibility with existing PKI solutions by adopting the standard behavior for key and signature encoding.

Before being formatted to PEM, keys/signatures are serialized using the DER ASN.1 notation (the same way as the go standard library).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-indigocore/260)
<!-- Reviewable:end -->
