### PR TITLE
*: bump version to 0.3.0-rc1

### DIFF
--- a/packages/agent-client-js/package.json
+++ b/packages/agent-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/client",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "Stratumn Indigo agent client library",
   "main": "lib/stratumn-agent-client.js",
   "module": "lib/stratumn-agent-client.mjs",
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/stratumn/js-indigocore",
   "devDependencies": {
-    "@indigocore/agent": "^0.2.0",
+    "@indigocore/agent": "^0.3.0-rc1",
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.2",
     "babel-plugin-external-helpers": "^6.8.0",
@@ -61,7 +61,7 @@
     "should": "^8.2.2"
   },
   "dependencies": {
-    "@indigocore/utils": "^0.2.0",
+    "@indigocore/utils": "^0.3.0-rc1",
     "asn1.js": "stratumn/asn1.js#master",
     "canonicaljson": "1.0.1",
     "deepmerge": "2.0.1",

--- a/packages/agent-js/package.json
+++ b/packages/agent-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/agent",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "NodeJS module that exposes functions to create Stratumn agents using Javascript",
   "main": "lib/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "url": "https://github.com/stratumn/js-indigocore/issues"
   },
   "dependencies": {
-    "@indigocore/utils": "^0.2.0",
+    "@indigocore/utils": "^0.3.0-rc1",
     "async-middleware": "^1.2.1",
     "babel-runtime": "^6.26.0",
     "body-parser": "^1.15.2",

--- a/packages/agent-sample/package.json
+++ b/packages/agent-sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/agent-sample",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "A sample Javascript agent.",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@indigocore/agent": "^0.2.0",
+    "@indigocore/agent": "^0.3.0-rc1",
     "express": "^4.14.0"
   },
   "devDependencies": {

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/agent-ui",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "Stratumn agent user interface",
   "author": "Stratumn team",
   "license": "Apache-2.0",
@@ -25,8 +25,8 @@
   },
   "private": true,
   "dependencies": {
-    "@indigocore/client": "^0.2.0",
-    "@indigocore/react-mapexplorer": "^0.2.0",
+    "@indigocore/client": "^0.3.0-rc1",
+    "@indigocore/react-mapexplorer": "^0.3.0-rc1",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
     "history": "^4.7.2",

--- a/packages/angular-mapexplorer/package.json
+++ b/packages/angular-mapexplorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/angular-mapexplorer",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "AngularJS 1.6 directive to display an Indigo Map Explorer.",
   "author": "Stratumn Team",
   "license": "Apache-2.0",
@@ -21,8 +21,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@indigocore/cs-validator": "^0.2.0",
-    "@indigocore/mapexplorer-core": "^0.2.0",
+    "@indigocore/cs-validator": "^0.3.0-rc1",
+    "@indigocore/mapexplorer-core": "^0.3.0-rc1",
     "angular": "~1.5.11",
     "angular-animate": "~1.5.11",
     "angular-aria": "~1.5.11",

--- a/packages/angular2-mapexplorer/package.json
+++ b/packages/angular2-mapexplorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/angular2-mapexplorer",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "author": "Stratumn team",
   "license": "Apache-2.0",
   "angular-cli": {},
@@ -30,8 +30,8 @@
     "@angular/platform-browser": "^5.0.4",
     "@angular/platform-browser-dynamic": "^5.0.4",
     "@angular/router": "^5.0.4",
-    "@indigocore/cs-validator": "^0.2.0",
-    "@indigocore/mapexplorer-core": "^0.2.0",
+    "@indigocore/cs-validator": "^0.3.0-rc1",
+    "@indigocore/mapexplorer-core": "^0.3.0-rc1",
     "core-js": "^2.4.1",
     "rxjs": "^5.5.2",
     "ts-helpers": "^1.1.1",

--- a/packages/cs-validator/package.json
+++ b/packages/cs-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/cs-validator",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "Core library for building Map Explorer components",
   "main": "lib/cs-validator.js",
   "module": "lib/cs-validator.mjs",
@@ -67,7 +67,7 @@
     "zock": "^0.2.6"
   },
   "dependencies": {
-    "@indigocore/client": "^0.2.0",
+    "@indigocore/client": "^0.3.0-rc1",
     "canonicaljson": "^1.0.1",
     "deepmerge": "2.0.1",
     "httpplease": "^0.16.4",

--- a/packages/ember-mapexplorer/package.json
+++ b/packages/ember-mapexplorer/package.json
@@ -30,7 +30,7 @@
     "test:ci": "yarn build && yarn test && yarn lint:js"
   },
   "dependencies": {
-    "@indigocore/mapexplorer-core": "^0.2.0",
+    "@indigocore/mapexplorer-core": "^0.3.0-rc1",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-sass": "^7.0.0",

--- a/packages/mapexplorer-core/package.json
+++ b/packages/mapexplorer-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/mapexplorer-core",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "Core library for building Map Explorer components",
   "main": "lib/mapexplorer-core.js",
   "module": "lib/mapexplorer-core.mjs",
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/stratumn/js-indigocore",
   "devDependencies": {
-    "@indigocore/agent": "^0.2.0",
+    "@indigocore/agent": "^0.3.0-rc1",
     "@metahub/karma-rollup-preprocessor": "^3.0.4",
     "babel-cli": "^6.5.1",
     "babel-plugin-external-helpers": "^6.8.0",
@@ -68,7 +68,7 @@
     "zock": "^0.2.6"
   },
   "dependencies": {
-    "@indigocore/client": "^0.2.0",
+    "@indigocore/client": "^0.3.0-rc1",
     "d3-array": "^1.0.0",
     "d3-ease": "^1.0.0",
     "d3-hierarchy": "^1.0.0",

--- a/packages/react-mapexplorer/package.json
+++ b/packages/react-mapexplorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/react-mapexplorer",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "React component that displays a Map Explorer",
   "author": "Stratumn",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@indigocore/mapexplorer-core": "^0.2.0",
+    "@indigocore/mapexplorer-core": "^0.3.0-rc1",
     "radium": "^0.19.5"
   },
   "peerDependencies": {

--- a/packages/tmpop-explorer/package.json
+++ b/packages/tmpop-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/tmpop-explorer",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "Block Explorer for Indigo Tendermint Store",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigocore/utils",
-  "version": "0.2.0",
+  "version": "0.3.0-rc1",
   "description": "NodeJS module that exposes utils related to IndigoCore",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Since we renamed indigoframework to indigocore, docker images fail to build (`indigocore/0.2.0` is not published on npm). 
After discussing it with @t-bast, we don't think it's a big deal to bump the version on master because the rc1 is already published and we're getting closer to the release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-indigocore/268)
<!-- Reviewable:end -->
