### PR TITLE
refs: remove full segment inclusion

### DIFF
--- a/packages/agent-js/src/process.js
+++ b/packages/agent-js/src/process.js
@@ -151,7 +151,6 @@ export default class Process {
    * @param {object[]} [refs] - the optional list of references of the new map
    * @param {string} [refs.process] - ref process name from the same store
    * @param {string} [refs.linkHash] - ref linkHash from the same store
-   * @param {object} [refs.segment] - ref linked segment from another store
    * @param {string} [refs.meta] - ref type of relation
    * @param {...} args - the arguments to pass to the init function
    * @returns {Promise} - a promise that resolve with the segment
@@ -187,7 +186,6 @@ export default class Process {
    * @param {object[]} [refs] - the optional list of references of the new segment
    * @param {string} [refs.process] - ref process name from the same store
    * @param {string} [refs.linkHash] - ref linkHash from the same store
-   * @param {object} [refs.segment] - ref linked segment from another store
    * @param {string} [refs.meta] - ref type of relation
    * @param {...} args - the arguments to pass to the transition function
    * @returns {Promise} - a promise that resolve with the segment

--- a/packages/agent-js/src/processify.js
+++ b/packages/agent-js/src/processify.js
@@ -37,7 +37,7 @@ const loadRefs = refs => {
   }
 
   refs.forEach(ref => {
-    if ((!ref.process || !ref.linkHash) && ref.segment == null) {
+    if (!ref.process || !ref.linkHash) {
       throw new Error(`missing segment or (process and linkHash)`);
     }
   });

--- a/packages/agent-js/test/httpServer.js
+++ b/packages/agent-js/test/httpServer.js
@@ -344,7 +344,7 @@ describe('HttpServer()', () => {
         segment.link.state.should.deepEqual({ a: 1, b: 2, c: 3 });
         segment.link.meta.mapId.should.be.a.String();
         segment.link.meta.refs.should.be.an.Array();
-        segment.link.meta.refs.length.should.be.exactly(3);
+        segment.link.meta.refs.length.should.be.exactly(2);
         segment.meta.linkHash.should.be.exactly(hashJson(segment.link));
         return should(segment.meta.evidences.should.deepEqual([]));
       });

--- a/packages/agent-js/test/process.js
+++ b/packages/agent-js/test/process.js
@@ -253,7 +253,7 @@ describe('Process', () => {
           )
           .then(segment2 => {
             segment2.link.state.nbSeg.should.be.exactly(1);
-            segment2.link.state.nbErr.should.be.exactly(2);
+            segment2.link.state.nbErr.should.be.exactly(1);
             segment2.link.state.nbNull.should.be.exactly(0);
           })
       ));

--- a/packages/agent-js/test/process.js
+++ b/packages/agent-js/test/process.js
@@ -147,7 +147,7 @@ describe('Process', () => {
           segment.link.state.should.deepEqual({ a: 1, b: 2, c: 3 });
           segment.link.meta.mapId.should.be.a.String();
           segment.link.meta.refs.should.be.an.Array();
-          segment.link.meta.refs.length.should.be.exactly(3);
+          segment.link.meta.refs.length.should.be.exactly(2);
           segment.link.meta.process.should.be.exactly('basic');
           segment.meta.linkHash.should.be.exactly(hashJson(segment.link));
         }));
@@ -237,7 +237,7 @@ describe('Process', () => {
             );
             segment2.meta.linkHash.should.be.exactly(hashJson(segment2.link));
             segment2.link.meta.refs.should.be.an.Array();
-            segment2.link.meta.refs.length.should.be.exactly(3);
+            segment2.link.meta.refs.length.should.be.exactly(2);
           });
       });
     });

--- a/packages/agent-js/test/utils/refs.js
+++ b/packages/agent-js/test/utils/refs.js
@@ -24,33 +24,12 @@ export default {
       linkHash: l,
       meta: 'father'
     };
-    const goodSegment = {
-      segment: {
-        link: {
-          meta: {
-            mapId: '1cc3a5ee-54e4-4093-92f7-efa591f85382',
-            prevLinkHash:
-              '2f0d1bde3f163446d6f23e31bd0b43063ec07ea4128cf5a258208e9f80832735',
-            process: 'foobar',
-            stateHash:
-              '124c9b6c55def7bc177c81d98ba12898b018a534c3101961a4b683678fa2d679'
-          }
-        },
-        meta: {
-          linkHash:
-            'e312a9d43d1401eeb62af52810ee8b6b746b67835eb040755ccb1598a5c88411',
-          segmentUrl:
-            'http://localhost:3000/segments/e312a9d43d1401eeb62af52810ee8b6b746b67835eb040755ccb1598a5c88411'
-        }
-      },
-      meta: 'mother'
-    };
     const otherProcess = {
       process: 'foo',
       linkHash: l,
       meta: 'uncle'
     };
-    return [goodLink, goodSegment, otherProcess];
+    return [goodLink, otherProcess];
   },
 
   getInvalidRefs() {


### PR DESCRIPTION
Remove everything I could find that referenced the possibility of including a segment fully in a ref.
If I've missed something please let me know!