### PR TITLE
agent: introduce a client factory for client caching

### DIFF
--- a/packages/agent-js/README.md
+++ b/packages/agent-js/README.md
@@ -21,11 +21,11 @@ var actions = require('./lib/actions');
 
 // Creates an HTTP store client to save segments.
 // Assumes an HTTP store server is available on env.STRATUMN_STORE_URL or http://store:5000.
-var storeHttpClient = Agent.storeHttpClient(process.env.STRATUMN_STORE_URL || 'http://store:5000');
+var storeHttpClient = Agent.storeClientFactory.create(storeHttpClient, process.env.STRATUMN_STORE_URL || 'http://store:5000');
 
 // Creates an HTTP fossilizer client to fossilize segments.
 // Assumes an HTTP fossilizer server is available on env.STRATUMN_FOSSILIZER_URL or http://fossilizer:6000.
-var fossilizerHttpClient = Agent.fossilizerHttpClient(process.env.STRATUMN_FOSSILIZER_URL || 'http://fossilizer:6000');
+var fossilizerHttpClient = Agent.fossilizerClientFactory.create(fossilizerHttpClient, process.env.STRATUMN_FOSSILIZER_URL || 'http://fossilizer:6000');
 
 // Creates an agent
 var agent = Agent.create({

--- a/packages/agent-js/src/clientFactory.js
+++ b/packages/agent-js/src/clientFactory.js
@@ -1,0 +1,64 @@
+/*
+  Copyright 2018 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const factories = {};
+
+/**
+ * Returns a client factory (for store and fossilizer clients in practice) that caches the client it creates.
+ * @param {string} name
+ */
+function clientFactory(name) {
+  if (factories[name]) {
+    return factories[name];
+  }
+
+  let availableClients = {};
+
+  const factory = {
+    create(implementation, url) {
+      // If we already have an existing client for that url, re-use it
+      if (availableClients[url]) {
+        return availableClients[url];
+      }
+      const client = implementation(url);
+      availableClients[url] = client;
+      return client;
+    },
+
+    /**
+     * Returns basic information about the clients that have been created.
+     * @returns {Array} an array of clients basic information (currently only url).
+     */
+    getAvailableClients() {
+      return Object.keys(availableClients).map(url => ({
+        url
+      }));
+    },
+
+    /**
+     * Clears information about the clients created.
+     * Should only be used for tests setup.
+     */
+    clearAvailableClients() {
+      availableClients = {};
+    }
+  };
+  factories[name] = factory;
+  return factory;
+}
+
+export const storeClientFactory = clientFactory('store');
+export const fossilizerClientFactory = clientFactory('fossilizer');

--- a/packages/agent-js/src/clientFactory.js
+++ b/packages/agent-js/src/clientFactory.js
@@ -25,16 +25,20 @@ function clientFactory(name) {
     return factories[name];
   }
 
-  let availableClients = {};
-
   const factory = {
+    availableClients: {},
+    /**
+     * Create a new client if it has not been created already.
+     * Assumes that there can only be one client for a given URL.
+     * @param {*} implementation a function that creates a client
+     * @param {*} url the URL parameter to be passed to the implementation function
+     */
     create(implementation, url) {
-      // If we already have an existing client for that url, re-use it
-      if (availableClients[url]) {
-        return availableClients[url];
+      if (this.availableClients[url]) {
+        return this.availableClients[url];
       }
       const client = implementation(url);
-      availableClients[url] = client;
+      this.availableClients[url] = client;
       return client;
     },
 
@@ -43,7 +47,7 @@ function clientFactory(name) {
      * @returns {Array} an array of clients basic information (currently only url).
      */
     getAvailableClients() {
-      return Object.keys(availableClients).map(url => ({
+      return Object.keys(this.availableClients).map(url => ({
         url
       }));
     },
@@ -53,7 +57,7 @@ function clientFactory(name) {
      * Should only be used for tests setup.
      */
     clearAvailableClients() {
-      availableClients = {};
+      this.availableClients = {};
     }
   };
   factories[name] = factory;

--- a/packages/agent-js/src/create.js
+++ b/packages/agent-js/src/create.js
@@ -17,8 +17,7 @@
 import httpServer from './httpServer';
 import Process from './process';
 
-import { getAvailableFossilizers } from './fossilizerHttpClient';
-import { getAvailableStores } from './storeHttpClient';
+import { storeClientFactory, fossilizerClientFactory } from './clientFactory';
 import { FOSSILIZER_DID_FOSSILIZE_LINK, STORE_SAVED_LINKS } from './eventTypes';
 import { deepGet, base64ToHex, base64ToUnicode } from './utils';
 
@@ -191,8 +190,8 @@ export default function create(options) {
         )
         .then(map => ({
           processes: map,
-          stores: getAvailableStores(),
-          fossilizers: getAvailableFossilizers(),
+          stores: storeClientFactory.getAvailableClients(),
+          fossilizers: fossilizerClientFactory.getAvailableClients(),
           plugins: Object.keys(activePlugins).map(plugin => ({
             id: plugin,
             name: activePlugins[plugin].name,

--- a/packages/agent-js/src/fossilizerHttpClient.js
+++ b/packages/agent-js/src/fossilizerHttpClient.js
@@ -22,16 +22,9 @@ import handleResponse from './handleResponse';
 /**
  * Creates a fossilizer HTTP client.
  * @param {string} url - the base URL of the fossilizer
- * @param {object} [opts] - options
- * @param {function} [opts.callbackUrl] - builds a URL that will be called with the evidence
  * @returns {Client} a fossilizer HTTP client
  */
 export default function fossilizerHttpClient(url) {
-  // If we already have an existing fossilizer for that url, re-use it
-  if (fossilizerHttpClient.availableFossilizers[url]) {
-    return fossilizerHttpClient.availableFossilizers[url];
-  }
-
   // Web socket URL.
   const wsUrl = `${url.replace(/^http/, 'ws')}/websocket`;
 
@@ -57,7 +50,7 @@ export default function fossilizerHttpClient(url) {
     });
   }
 
-  const fossilizerClient = Object.assign(emitter, {
+  return Object.assign(emitter, {
     /**
      * Gets information about the fossilizer.
      * @returns {Promise} a promise that resolve with the information
@@ -103,28 +96,4 @@ export default function fossilizerHttpClient(url) {
       });
     }
   });
-
-  fossilizerHttpClient.availableFossilizers[url] = fossilizerClient;
-
-  return fossilizerClient;
-}
-
-fossilizerHttpClient.availableFossilizers = {};
-
-/**
- * Returns basic information about the fossilizer HTTP clients that have been created.
- * @returns {Array} an array of fossilizer HTTP clients basic information (currently only url).
- */
-export function getAvailableFossilizers() {
-  return Object.keys(fossilizerHttpClient.availableFossilizers).map(url => ({
-    url
-  }));
-}
-
-/**
- * Clears information about the fossilizer HTTP clients created.
- * Should only be used for tests setup.
- */
-export function clearAvailableFossilizers() {
-  fossilizerHttpClient.availableFossilizers = {};
 }

--- a/packages/agent-js/src/index.js
+++ b/packages/agent-js/src/index.js
@@ -21,15 +21,18 @@ import memoryStore from './memoryStore';
 import plugins from './plugins';
 import storeHttpClient from './storeHttpClient';
 import websocketServer from './websocketServer';
+import { storeClientFactory, fossilizerClientFactory } from './clientFactory';
 import processify from './processify';
 
 module.exports = {
   create,
+  fossilizerClientFactory,
   fossilizerHttpClient,
   httpServer,
   memoryStore,
   plugins,
   processify,
+  storeClientFactory,
   storeHttpClient,
   websocketServer
 };

--- a/packages/agent-js/src/storeHttpClient.js
+++ b/packages/agent-js/src/storeHttpClient.js
@@ -35,11 +35,6 @@ import handleResponse from './handleResponse';
  * @returns {Client} a store HTTP client
  */
 export default function storeHttpClient(url) {
-  // If we already have an existing store for that url, re-use it
-  if (storeHttpClient.availableStores[url]) {
-    return storeHttpClient.availableStores[url];
-  }
-
   // Web socket URL.
   const wsUrl = `${url.replace(/^http/, 'ws')}/websocket`;
 
@@ -66,7 +61,7 @@ export default function storeHttpClient(url) {
     });
   }
 
-  const storeClient = Object.assign(emitter, {
+  return Object.assign(emitter, {
     /**
      * Gets information about the store.
      * @returns {Promise} a promise that resolve with the information
@@ -187,26 +182,4 @@ export default function storeHttpClient(url) {
       });
     }
   });
-
-  storeHttpClient.availableStores[url] = storeClient;
-
-  return storeClient;
-}
-
-storeHttpClient.availableStores = {};
-
-/**
- * Returns basic information about the store HTTP clients that have been created.
- * @returns {Array} an array of store HTTP clients basic information (currently only url).
- */
-export function getAvailableStores() {
-  return Object.keys(storeHttpClient.availableStores).map(url => ({ url }));
-}
-
-/**
- * Clears information about the store HTTP clients created.
- * Should only be used for tests setup.
- */
-export function clearAvailableStores() {
-  storeHttpClient.availableStores = {};
 }

--- a/packages/agent-js/test/clientFactory.js
+++ b/packages/agent-js/test/clientFactory.js
@@ -1,0 +1,53 @@
+/*
+  Copyright 2018 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import storeHttpClient from '../src/storeHttpClient';
+import { storeClientFactory } from '../src/clientFactory';
+
+describe('storeClientFactory', () => {
+  describe('#getAvailableClients()', () => {
+    beforeEach(() => {
+      storeClientFactory.clearAvailableClients();
+    });
+
+    it('tracks fossilizer clients that are created', () => {
+      storeClientFactory.create(storeHttpClient, 'http://fossilizer1:6000');
+      storeClientFactory.create(storeHttpClient, 'http://fossilizer2:6001');
+
+      storeClientFactory.getAvailableClients().length.should.be.exactly(2);
+      storeClientFactory
+        .getAvailableClients()[0]
+        .url.should.be.exactly('http://fossilizer1:6000');
+      storeClientFactory
+        .getAvailableClients()[1]
+        .url.should.be.exactly('http://fossilizer2:6001');
+    });
+
+    it('does not create duplicate fossilizers for the same url', () => {
+      const storeClient1 = storeClientFactory.create(
+        storeHttpClient,
+        'http://fossilizer:6000'
+      );
+      const storeClient2 = storeClientFactory.create(
+        storeHttpClient,
+        'http://fossilizer:6000'
+      );
+
+      storeClientFactory.getAvailableClients().length.should.be.exactly(1);
+      storeClient1.should.equal(storeClient2);
+    });
+  });
+});

--- a/packages/agent-js/test/create.js
+++ b/packages/agent-js/test/create.js
@@ -22,10 +22,12 @@ import plugins from '../src/plugins';
 import Process from '../src/process';
 import actions from './utils/basicActions';
 
-import fossilizerHttpClient, {
-  clearAvailableFossilizers
-} from '../src/fossilizerHttpClient';
-import storeHttpClient, { clearAvailableStores } from '../src/storeHttpClient';
+import fossilizerHttpClient from '../src/fossilizerHttpClient';
+import storeHttpClient from '../src/storeHttpClient';
+import {
+  storeClientFactory,
+  fossilizerClientFactory
+} from '../src/clientFactory';
 import { FOSSILIZER_DID_FOSSILIZE_LINK } from '../src/eventTypes';
 
 const dummyFossilizer = {
@@ -46,8 +48,8 @@ describe('Agent', () => {
 
   beforeEach(() => {
     agent = create({ agentUrl: 'http://localhost' });
-    clearAvailableFossilizers();
-    clearAvailableStores();
+    storeClientFactory.clearAvailableClients();
+    fossilizerClientFactory.clearAvailableClients();
   });
 
   afterEach(() => {
@@ -67,7 +69,10 @@ describe('Agent', () => {
     });
 
     it('returns a Promise resolving with information about the existing fossilizers', () => {
-      fossilizerHttpClient('http://fossilizer:6000');
+      fossilizerClientFactory.create(
+        fossilizerHttpClient,
+        'http://fossilizer:6000'
+      );
 
       return agent.getInfo().then(infos => {
         infos.fossilizers.should.be.an.Object();
@@ -77,7 +82,7 @@ describe('Agent', () => {
     });
 
     it('returns a Promise resolving with information about the existing stores', () => {
-      storeHttpClient('http://store:5000');
+      storeClientFactory.create(storeHttpClient, 'http://store:5000');
 
       return agent.getInfo().then(infos => {
         infos.stores.should.be.an.Object();

--- a/packages/agent-js/test/fossilizerHttpClient.js
+++ b/packages/agent-js/test/fossilizerHttpClient.js
@@ -16,10 +16,7 @@
 
 import request from 'superagent';
 import mocker from 'superagent-mocker';
-import fossilizerHttpClient, {
-  getAvailableFossilizers,
-  clearAvailableFossilizers
-} from '../src/fossilizerHttpClient';
+import fossilizerHttpClient from '../src/fossilizerHttpClient';
 import mockFossilizerHttpServer from './utils/mockFossilizerHttpServer';
 
 const fossilizerClient = fossilizerHttpClient('http://localhost');
@@ -27,33 +24,6 @@ const fossilizerClient = fossilizerHttpClient('http://localhost');
 mockFossilizerHttpServer(mocker(request));
 
 describe('FossilizerHttpClient', () => {
-  describe('#getAvailableFossilizers()', () => {
-    beforeEach(() => {
-      clearAvailableFossilizers();
-    });
-
-    it('tracks fossilizer clients that are created', () => {
-      fossilizerHttpClient('http://fossilizer1:6000');
-      fossilizerHttpClient('http://fossilizer2:6001');
-
-      getAvailableFossilizers().length.should.be.exactly(2);
-      getAvailableFossilizers()[0].url.should.be.exactly(
-        'http://fossilizer1:6000'
-      );
-      getAvailableFossilizers()[1].url.should.be.exactly(
-        'http://fossilizer2:6001'
-      );
-    });
-
-    it('does not create duplicate fossilizers for the same url', () => {
-      const fossilizerClient1 = fossilizerHttpClient('http://fossilizer:6000');
-      const fossilizerClient2 = fossilizerHttpClient('http://fossilizer:6000');
-
-      getAvailableFossilizers().length.should.be.exactly(1);
-      fossilizerClient1.should.equal(fossilizerClient2);
-    });
-  });
-
   describe('#getInfo()', () => {
     it('resolves with the fossilizer info', () =>
       fossilizerHttpClient('http://localhost')

--- a/packages/agent-js/test/storeHttpClient.js
+++ b/packages/agent-js/test/storeHttpClient.js
@@ -17,38 +17,12 @@
 import request from 'superagent';
 import mocker from 'superagent-mocker';
 import should from 'should';
-import storeHttpClient, {
-  getAvailableStores,
-  clearAvailableStores
-} from '../src/storeHttpClient';
+import storeHttpClient from '../src/storeHttpClient';
 import mockStoreHttpServer from './utils/mockStoreHttpServer';
 
 mockStoreHttpServer(mocker(request));
 
 describe('StoreHttpClient', () => {
-  describe('#getAvailableStores()', () => {
-    beforeEach(() => {
-      clearAvailableStores();
-    });
-
-    it('tracks store clients that are created', () => {
-      storeHttpClient('http://store1:5000');
-      storeHttpClient('http://store2:5001');
-
-      getAvailableStores().length.should.be.exactly(2);
-      getAvailableStores()[0].url.should.be.exactly('http://store1:5000');
-      getAvailableStores()[1].url.should.be.exactly('http://store2:5001');
-    });
-
-    it('does not create duplicate stores for the same url', () => {
-      const storeClient1 = storeHttpClient('http://store:5000');
-      const storeClient2 = storeHttpClient('http://store:5000');
-
-      getAvailableStores().length.should.be.exactly(1);
-      storeClient1.should.equal(storeClient2);
-    });
-  });
-
   describe('#getInfo()', () => {
     it('resolves with the store info', () =>
       storeHttpClient('http://localhost')


### PR DESCRIPTION
The way we used to cache the clients created was not compatible with
having mutliple client implementation. For instance, the agent object
should not depend directly on a client implementation as it used to be
the case. This forces the user of the Agent to use a factory to
instantiate its clients though (as seen in the README).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-indigocore/283)
<!-- Reviewable:end -->
